### PR TITLE
fix(skills): standardize stale tool name references across 5 skills

### DIFF
--- a/plugins/webflow-skills/skills/bulk-cms-update/SKILL.md
+++ b/plugins/webflow-skills/skills/bulk-cms-update/SKILL.md
@@ -316,7 +316,7 @@ Fix item 2 or skip it? (fix/skip)
 ### Phase 1: Critical Requirements
 
 **Site & Collection Selection:**
-- Always fetch actual site list using `sites_list`
+- Always fetch actual site list using `data_sites_tool` with action `list_sites`
 - Never assume site IDs
 - Show collection names and item counts
 - Display field schema before accepting data
@@ -364,13 +364,13 @@ When fetching existing items for updates, use filter parameters to minimize API 
 
 ```
 # Good - Filter by name when you know the item name
-collections_items_list_items(collection_id, name: "Pikachu")
+data_cms_tool(action: "list_collection_items", collection_id, name: "Pikachu")
 
 # Good - Filter by slug when you know the slug
-collections_items_list_items(collection_id, slug: "pikachu")
+data_cms_tool(action: "list_collection_items", collection_id, slug: "pikachu")
 
 # Bad - Fetching all items then searching through results
-collections_items_list_items(collection_id)  # Returns 100 items
+data_cms_tool(action: "list_collection_items", collection_id)  # Returns 100 items
 # Then manually searching for "Pikachu" in results...
 ```
 

--- a/plugins/webflow-skills/skills/cms-best-practices/SKILL.md
+++ b/plugins/webflow-skills/skills/cms-best-practices/SKILL.md
@@ -1296,7 +1296,7 @@ Let me know what you'd like me to check!
 ### Phase 1: Discovery Best Practices
 
 **Always Start With:**
-1. **Identify plan limits** - Use `sites_get` to check collection/item limits
+1. **Identify plan limits** - Use `data_sites_tool` with action `get_site` to check collection/item limits
 2. **Analyze existing structure** - List collections before recommending changes
 3. **Understand content volume** - Check item counts to assess scale
 4. **Review current pages** - See how content is currently displayed

--- a/plugins/webflow-skills/skills/cms-collection-setup/SKILL.md
+++ b/plugins/webflow-skills/skills/cms-collection-setup/SKILL.md
@@ -708,7 +708,7 @@ Relationships Configured:
 ### Phase 1: Discovery Best Practices
 
 **Site Selection:**
-- Always use `sites_list` to get available sites
+- Always use `data_sites_tool` with action `list_sites` to get available sites
 - Never assume site ID
 - Verify user has correct site selected
 
@@ -932,14 +932,14 @@ Field Type → Tool to use:
 
 PlainText, RichText, Email, Phone, Link, Number,
 Image, MultiImage, File, Video, DateTime, Switch, Color
-→ collection_fields_create_static
+→ data_cms_tool with action create_collection_static_field
 
 Option
-→ collection_fields_create_option
+→ data_cms_tool with action create_collection_option_field
    (requires metadata.options array)
 
 Reference, MultiReference
-→ collection_fields_create_reference
+→ data_cms_tool with action create_collection_reference_field
    (requires metadata.collectionId)
 ```
 

--- a/plugins/webflow-skills/skills/safe-publish/SKILL.md
+++ b/plugins/webflow-skills/skills/safe-publish/SKILL.md
@@ -42,7 +42,7 @@ Publish a Webflow site with comprehensive preview, validation, and explicit conf
    - Categorize by type (static, CMS template, archived, draft)
 6. **List all collections**: Use Webflow MCP's `data_cms_tool` with action `get_collection_list`
 7. **Check for draft items**:
-   - For each collection, use Webflow MCP's `collections_items_list_items`
+   - For each collection, use Webflow MCP's `data_cms_tool` with action `list_collection_items`
    - Count items where `isDraft: true`
    - Count items modified since last publish
 8. **Detect issues**:
@@ -267,7 +267,7 @@ All unpublished changes have been successfully published to the Webflow subdomai
 ### Phase 1: Critical Requirements
 
 **Site Status Check:**
-- Always fetch complete site details using `sites_get`
+- Always fetch complete site details using `data_sites_tool` with action `get_site`
 - Compare `lastUpdated` vs `lastPublished` to detect unpublished changes
 - If timestamps are identical, inform user "No changes to publish"
 - If `lastPublished` is null, warn "First publish - entire site will go live"
@@ -297,8 +297,8 @@ All unpublished changes have been successfully published to the Webflow subdomai
   - Archived (won't appear on site)
 
 **Collections to Check:**
-- Query all collections with `collections_list`
-- For each collection, list items with `collections_items_list_items`
+- Query all collections with `data_cms_tool` with action `get_collection_list`
+- For each collection, list items with `data_cms_tool` with action `list_collection_items`
 - Batch queries if site has many collections (10+ collections)
 
 ### Phase 3: Pre-Publish Validation
@@ -343,7 +343,7 @@ All unpublished changes have been successfully published to the Webflow subdomai
 
 **Publish API Usage:**
 ```javascript
-// Correct format for sites_publish
+// Correct format for data_sites_tool with action publish_site
 {
   "site_id": "site-id-here",
   "publishToWebflowSubdomain": true,  // or false
@@ -376,7 +376,7 @@ All unpublished changes have been successfully published to the Webflow subdomai
 
 **Post-Publish Verification:**
 1. **Fetch Updated Site Info:**
-   - Call `sites_get` again
+   - Call `data_sites_tool` with action `get_site` again
    - Verify `lastPublished` timestamp updated
    - If timestamp didn't update, publish may have failed
 

--- a/plugins/webflow-skills/skills/site-audit/SKILL.md
+++ b/plugins/webflow-skills/skills/site-audit/SKILL.md
@@ -53,8 +53,8 @@ Comprehensive audit of a Webflow site's structure, content health, and quality w
 ### Phase 3: CMS Collections Inventory
 7. **List all collections**: Use Webflow MCP's `data_cms_tool` with action `get_collection_list`
 8. **For each collection**:
-   - Get detailed schema using Webflow MCP's `collections_get`
-   - Count items using Webflow MCP's `collections_items_list_items`
+   - Get detailed schema using Webflow MCP's `data_cms_tool` with action `get_collection_details`
+   - Count items using Webflow MCP's `data_cms_tool` with action `list_collection_items`
    - Analyze field types and requirements
    - Identify required vs optional fields
    - Detect reference fields and relationships
@@ -217,7 +217,7 @@ Which format would you like? (1/2/3)
 ### Phase 1: Critical Requirements
 
 **Site Information:**
-- Always fetch complete site details using `sites_get`
+- Always fetch complete site details using `data_sites_tool` with action `get_site`
 - Include last published and last updated dates
 - Show timezone and locale information
 - Display custom domains if configured
@@ -346,8 +346,8 @@ Generate separate files:
 - Provide estimated time for large sites
 
 **Error Handling:**
-- If `pages_list` fails, continue with collections
-- If `collections_get` fails, show basic collection info
+- If `data_pages_tool` with action `list_pages` fails, continue with collections
+- If `data_cms_tool` with action `get_collection_details` fails, show basic collection info
 - Report partial successes separately
 - Offer to retry failed operations
 


### PR DESCRIPTION
## Summary

Replace old API-style tool names with the correct MCP format across 5 skills. The Important Note sections already declared the correct names, but Instructions and Guidelines sections still referenced the old format.

## Skills Fixed

| Skill | Old Names Replaced |
|---|---|
| **safe-publish** | `collections_items_list_items`, `sites_get`, `collections_list`, `sites_publish` |
| **bulk-cms-update** | `sites_list`, `collections_items_list_items` |
| **site-audit** | `collections_get`, `collections_items_list_items`, `sites_get`, `pages_list` |
| **cms-best-practices** | `sites_get` |
| **cms-collection-setup** | `sites_list`, `collection_fields_create_static`, `collection_fields_create_option`, `collection_fields_create_reference` |

## Replacements

| Old Name | New MCP Format |
|---|---|
| `sites_list` | `data_sites_tool` with action `list_sites` |
| `sites_get` | `data_sites_tool` with action `get_site` |
| `sites_publish` | `data_sites_tool` with action `publish_site` |
| `collections_get` | `data_cms_tool` with action `get_collection_details` |
| `collections_list` | `data_cms_tool` with action `get_collection_list` |
| `collections_items_list_items` | `data_cms_tool` with action `list_collection_items` |
| `collection_fields_create_*` | `data_cms_tool` with action `create_collection_*_field` |
| `pages_list` | `data_pages_tool` with action `list_pages` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)