### PR TITLE
fix(skills): rewrite custom-code-management with full workflow and missing sections

### DIFF
--- a/plugins/webflow-skills/skills/custom-code-management/SKILL.md
+++ b/plugins/webflow-skills/skills/custom-code-management/SKILL.md
@@ -1,50 +1,175 @@
 ---
 name: custom-code-management
-description: Add, review, or remove inline custom scripts on a Webflow site (up to 10,000 chars). Use for analytics, tracking pixels, chat widgets, or any custom JavaScript.
+description: Add, review, or remove inline custom scripts on a Webflow site (up to 10,000 chars). Use for analytics, tracking pixels, chat widgets, or any custom JavaScript. Also manages page-level scripts.
 ---
 
 # Custom Code Management
 
-## Concepts
+Add, review, and manage inline custom scripts on a Webflow site — analytics, tracking pixels, chat widgets, or any custom JavaScript.
 
-Webflow custom code: **register** (store script) → **apply** (attach to site). Inline scripts only via MCP (max 10,000 chars).
-
-## Important note
+## Important Note
 
 **ALWAYS use Webflow MCP tools for all operations:**
-Use the following tools for all operations:
-- `data_scripts_tool` with actions `list_registered_scripts` / `list_applied_scripts` - List scripts
-- `data_scripts_tool` with action `add_inline_site_script` - Register inline script (no `<script>` tags)
-- `data_scripts_tool` with action `delete_all_site_scripts` - Remove ALL scripts (no selective delete)
-- `data_sites_tool` with action `list_sites` - List available sites
+- Use Webflow MCP's `webflow_guide_tool` to get best practices **before any other tool call**
+- Use Webflow MCP's `data_sites_tool` with action `list_sites` to identify available sites
+- Use Webflow MCP's `data_scripts_tool` with action `list_registered_scripts` to list all registered scripts
+- Use Webflow MCP's `data_scripts_tool` with action `list_applied_scripts` to list scripts applied to pages
+- Use Webflow MCP's `data_scripts_tool` with action `add_inline_site_script` to register a new inline script
+- Use Webflow MCP's `data_scripts_tool` with action `delete_all_site_scripts` to remove ALL site scripts (no selective delete)
+- Use Webflow MCP's `data_scripts_tool` with action `get_page_script` to get custom code for a specific page
+- Use Webflow MCP's `data_scripts_tool` with action `upsert_page_script` to add or update page-level custom code
+- Use Webflow MCP's `data_scripts_tool` with action `delete_all_page_scripts` to remove all custom code from a page
+- DO NOT use any other tools or methods for Webflow operations
+- All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
+- Inline scripts only — max 10,000 characters per script
+- Do NOT include `<script>` tags in script content (Webflow adds them automatically)
 
 ## Instructions
 
-### View Scripts
-1. Call `data_sites_tool` with action `list_sites` if needed, then call both list tools in parallel
-2. Display registration and application status
+### Phase 1: Discovery
+1. **Call `webflow_guide_tool` first** — always the first MCP tool call in any workflow
+2. **Get the site**: Use `data_sites_tool` with action `list_sites` to identify the target site. If only one site exists, use it automatically.
+3. **Identify the task type**:
+   - **View/Audit**: List scripts, check what's installed → go to Phase 2
+   - **Add/Update**: Add new script or update page code → go to Phase 3
+   - **Remove**: Delete scripts → go to Phase 3
 
-### Add Script
-1. Gather: name, code, location (header/footer)
-2. Validate: under 10,000 chars, no `<script>` tags
-3. Preview with character count, require **"add"** to confirm
-4. Call `data_scripts_tool` with action `add_inline_site_script` with displayName, sourceCode, version, location, canCopy
-5. Remind user to publish
+### Phase 2: Analysis (read-only operations)
+4. **List registered scripts**: Use `data_scripts_tool` with action `list_registered_scripts` to see all scripts registered on the site
+5. **List applied scripts**: Use `data_scripts_tool` with action `list_applied_scripts` to see where scripts are applied
+6. **Check page-level scripts** (if relevant): Use `data_scripts_tool` with action `get_page_script` to inspect custom code on specific pages
+7. **Present findings**: Summarize scripts by:
+   - Name, version, and location (header/footer)
+   - Registration vs application status
+   - Character count and content preview
+   - Page-level vs site-level scope
 
-### Remove Scripts
-1. List current scripts
-2. Warn: removes ALL scripts (no selective delete)
-3. Require **"delete all"** to confirm
-4. Remind user to publish
+### Phase 3: Planning (before any mutation)
+Before adding, updating, or deleting anything:
+8. **Present the plan**: Describe exactly what will be changed
+9. **Request explicit confirmation**:
+   - For adding scripts: User must type **"add"** to confirm
+   - For removing ALL site scripts: User must type **"delete all"** to confirm
+   - For page-level changes: User must type **"update"** to confirm
+10. **Warn about side effects**:
+    - `delete_all_site_scripts` removes ALL scripts — there is no selective delete
+    - Adding a script with an existing `displayName + version` will fail
+    - Remind user that changes require publishing to go live
 
-## Constraints
+### Phase 4: Execution (after confirmation only)
+11. **Add site script**: Use `data_scripts_tool` with action `add_inline_site_script`
+    - Required fields: `displayName`, `sourceCode`, `version`, `location` (header/footer), `canCopy`
+    - Validate: under 10,000 chars, no `<script>` tags
+12. **Remove all site scripts**: Use `data_scripts_tool` with action `delete_all_site_scripts`
+13. **Add/update page script**: Use `data_scripts_tool` with action `upsert_page_script`
+14. **Remove page scripts**: Use `data_scripts_tool` with action `delete_all_page_scripts`
 
-- Max 10,000 characters per script
-- Do NOT include `<script>` tags (Webflow adds them)
-- displayName + version must be unique
-- Site-level only (no page-specific via MCP)
-- Hosted scripts not available via MCP
+### Phase 5: Verification & Reporting
+15. **Verify the change**: Re-list scripts to confirm the operation succeeded
+16. **Report what changed**: Summarize the script name, location, version, and character count
+17. **Remind about publishing**: Suggest using the `safe-publish` skill to publish changes to make them live
 
-## Response Format
+## Examples
 
-After adding a script, respond with the script name, location, and version. Suggest using the `safe-publish` skill to publish changes.
+### Example 1: View all scripts on a site
+
+**User:** "What scripts are installed on my site?"
+
+1. Call `webflow_guide_tool` for best practices
+2. Call `data_sites_tool` with `list_sites` to identify the site
+3. Call `data_scripts_tool` with `list_registered_scripts` and `list_applied_scripts` in parallel
+4. Present organized summary of all scripts with name, version, location, and status
+
+### Example 2: Add Google Tag Manager
+
+**User:** "Add Google Tag Manager to my site"
+
+1. Call `webflow_guide_tool` for best practices
+2. Call `data_sites_tool` with `list_sites` to identify the site
+3. Ask user for their GTM container ID (e.g., GTM-XXXXXXX)
+4. Present plan: "I'll add a GTM script to the header with your container ID. Type **add** to confirm."
+5. After confirmation: call `data_scripts_tool` with `add_inline_site_script`:
+   - displayName: "Google Tag Manager"
+   - sourceCode: GTM initialization snippet (without `<script>` tags)
+   - version: "1.0.0"
+   - location: "header"
+   - canCopy: false
+6. Verify by re-listing scripts
+7. Remind user to publish
+
+### Example 3: Remove all scripts
+
+**User:** "Remove all custom scripts from my site"
+
+1. Call `webflow_guide_tool` for best practices
+2. Call `data_sites_tool` with `list_sites` to identify the site
+3. Call `data_scripts_tool` with `list_registered_scripts` to show what will be deleted
+4. Warn: "This will remove ALL scripts — there is no selective delete. Type **delete all** to confirm."
+5. After confirmation: call `data_scripts_tool` with `delete_all_site_scripts`
+6. Verify by re-listing scripts
+7. Remind user to publish
+
+### Example 4: Add a chat widget script
+
+**User:** "Add an Intercom chat widget to my site"
+
+1. Call `webflow_guide_tool` for best practices
+2. Call `data_sites_tool` with `list_sites` to identify the site
+3. Ask user for their Intercom app ID
+4. Present plan with script preview and character count
+5. After "add" confirmation: call `data_scripts_tool` with `add_inline_site_script`:
+   - displayName: "Intercom Chat Widget"
+   - sourceCode: Intercom initialization snippet
+   - version: "1.0.0"
+   - location: "footer"
+   - canCopy: false
+6. Verify and remind user to publish
+
+### Example 5: Add page-specific tracking
+
+**User:** "Add conversion tracking to my thank-you page"
+
+1. Call `webflow_guide_tool` for best practices
+2. Call `data_sites_tool` with `list_sites` to identify the site
+3. Call `data_scripts_tool` with `get_page_script` to check existing page scripts
+4. Present plan: "I'll add conversion tracking code to the thank-you page. Type **update** to confirm."
+5. After confirmation: call `data_scripts_tool` with `upsert_page_script`
+6. Verify by calling `get_page_script` again
+7. Remind user to publish
+
+## Guidelines
+
+### Script Content Rules
+- Maximum 10,000 characters per script
+- Do NOT include `<script>` tags — Webflow adds them automatically
+- `displayName` + `version` must be unique per site
+- Use semantic version numbers (e.g., "1.0.0", "2.1.0")
+- Use descriptive display names (e.g., "Google Tag Manager", not "GTM")
+
+### Confirmation Requirements
+- **Adding scripts**: Require user to type "add"
+- **Deleting ALL site scripts**: Require user to type "delete all"
+- **Updating page scripts**: Require user to type "update"
+- Do NOT accept generic confirmations ("yes", "ok", "go") for destructive operations
+- Always show a preview of the script content before adding
+
+### Scope Awareness
+- Site-level scripts (`add_inline_site_script`) apply to all pages
+- Page-level scripts (`upsert_page_script`) apply to a specific page only
+- `delete_all_site_scripts` removes ALL site-level scripts — no selective delete available
+- `delete_all_page_scripts` removes all scripts from a specific page
+- Hosted/external scripts are not available via MCP — only inline scripts
+
+### Safety and Best Practices
+- Always list existing scripts before adding new ones to avoid duplicates
+- Warn users about the destructive nature of `delete_all_site_scripts`
+- Remind users to publish after any script changes
+- Suggest using the `safe-publish` skill for publishing
+- For analytics scripts (GA, GTM), recommend header placement
+- For chat widgets and non-critical scripts, recommend footer placement
+- Validate script content doesn't contain malicious patterns
+
+### Error Handling
+- If `displayName + version` already exists, suggest incrementing the version
+- If script exceeds 10,000 chars, suggest splitting or hosting externally
+- If site has no scripts to delete, inform user — don't call delete

--- a/plugins/webflow-skills/skills/custom-code-management/SKILL.md
+++ b/plugins/webflow-skills/skills/custom-code-management/SKILL.md
@@ -19,157 +19,69 @@ Add, review, and manage inline custom scripts on a Webflow site — analytics, t
 - Use Webflow MCP's `data_scripts_tool` with action `get_page_script` to get custom code for a specific page
 - Use Webflow MCP's `data_scripts_tool` with action `upsert_page_script` to add or update page-level custom code
 - Use Webflow MCP's `data_scripts_tool` with action `delete_all_page_scripts` to remove all custom code from a page
-- DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- Inline scripts only — max 10,000 characters per script
-- Do NOT include `<script>` tags in script content (Webflow adds them automatically)
 
 ## Instructions
 
 ### Phase 1: Discovery
-1. **Call `webflow_guide_tool` first** — always the first MCP tool call in any workflow
-2. **Get the site**: Use `data_sites_tool` with action `list_sites` to identify the target site. If only one site exists, use it automatically.
-3. **Identify the task type**:
-   - **View/Audit**: List scripts, check what's installed → go to Phase 2
-   - **Add/Update**: Add new script or update page code → go to Phase 3
-   - **Remove**: Delete scripts → go to Phase 3
+1. **Call `webflow_guide_tool` first** — always the first MCP tool call
+2. **Get the site**: Use `data_sites_tool` with action `list_sites`. If only one site, use it automatically.
 
-### Phase 2: Analysis (read-only operations)
-4. **List registered scripts**: Use `data_scripts_tool` with action `list_registered_scripts` to see all scripts registered on the site
-5. **List applied scripts**: Use `data_scripts_tool` with action `list_applied_scripts` to see where scripts are applied
-6. **Check page-level scripts** (if relevant): Use `data_scripts_tool` with action `get_page_script` to inspect custom code on specific pages
-7. **Present findings**: Summarize scripts by:
-   - Name, version, and location (header/footer)
-   - Registration vs application status
-   - Character count and content preview
-   - Page-level vs site-level scope
+### Phase 2: Analysis
+3. **List scripts**: Call `list_registered_scripts` and `list_applied_scripts` in parallel
+4. **Check page-level scripts** (if relevant): Use `get_page_script` for specific pages
+5. **Present findings**: Name, version, location (header/footer), registration vs application status
 
-### Phase 3: Planning (before any mutation)
-Before adding, updating, or deleting anything:
-8. **Present the plan**: Describe exactly what will be changed
-9. **Request explicit confirmation**:
-   - For adding scripts: User must type **"add"** to confirm
-   - For removing ALL site scripts: User must type **"delete all"** to confirm
-   - For page-level changes: User must type **"update"** to confirm
-10. **Warn about side effects**:
-    - `delete_all_site_scripts` removes ALL scripts — there is no selective delete
-    - Adding a script with an existing `displayName + version` will fail
-    - Remind user that changes require publishing to go live
+### Phase 3: Planning & Confirmation
+Before any mutation, present the plan and require explicit confirmation:
+- Adding scripts: user must type **"add"**
+- Removing ALL site scripts: user must type **"delete all"** (warn: no selective delete)
+- Page-level changes: user must type **"update"**
 
-### Phase 4: Execution (after confirmation only)
-11. **Add site script**: Use `data_scripts_tool` with action `add_inline_site_script`
-    - Required fields: `displayName`, `sourceCode`, `version`, `location` (header/footer), `canCopy`
-    - Validate: under 10,000 chars, no `<script>` tags
-12. **Remove all site scripts**: Use `data_scripts_tool` with action `delete_all_site_scripts`
-13. **Add/update page script**: Use `data_scripts_tool` with action `upsert_page_script`
-14. **Remove page scripts**: Use `data_scripts_tool` with action `delete_all_page_scripts`
+### Phase 4: Execution
+6. **Add site script**: `add_inline_site_script` with displayName, sourceCode, version, location, canCopy
+7. **Remove all site scripts**: `delete_all_site_scripts`
+8. **Add/update page script**: `upsert_page_script`
+9. **Remove page scripts**: `delete_all_page_scripts`
 
-### Phase 5: Verification & Reporting
-15. **Verify the change**: Re-list scripts to confirm the operation succeeded
-16. **Report what changed**: Summarize the script name, location, version, and character count
-17. **Remind about publishing**: Suggest using the `safe-publish` skill to publish changes to make them live
+### Phase 5: Verification
+10. Re-list scripts to confirm success
+11. Report what changed (name, location, version, char count)
+12. Remind user to publish — suggest using `safe-publish` skill
 
 ## Examples
 
-### Example 1: View all scripts on a site
-
-**User:** "What scripts are installed on my site?"
-
-1. Call `webflow_guide_tool` for best practices
-2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `data_scripts_tool` with `list_registered_scripts` and `list_applied_scripts` in parallel
-4. Present organized summary of all scripts with name, version, location, and status
+### Example 1: View scripts
+**User:** "What scripts are on my site?"
+1. `webflow_guide_tool` → `data_sites_tool` → `list_registered_scripts` + `list_applied_scripts` in parallel
+2. Present summary of all scripts
 
 ### Example 2: Add Google Tag Manager
-
-**User:** "Add Google Tag Manager to my site"
-
-1. Call `webflow_guide_tool` for best practices
-2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Ask user for their GTM container ID (e.g., GTM-XXXXXXX)
-4. Present plan: "I'll add a GTM script to the header with your container ID. Type **add** to confirm."
-5. After confirmation: call `data_scripts_tool` with `add_inline_site_script`:
-   - displayName: "Google Tag Manager"
-   - sourceCode: GTM initialization snippet (without `<script>` tags)
-   - version: "1.0.0"
-   - location: "header"
-   - canCopy: false
-6. Verify by re-listing scripts
-7. Remind user to publish
+**User:** "Add GTM to my site"
+1. `webflow_guide_tool` → `data_sites_tool` → ask for GTM container ID
+2. Preview script, require "add" → `add_inline_site_script` (header, version "1.0.0")
+3. Verify and remind to publish
 
 ### Example 3: Remove all scripts
+**User:** "Remove all scripts"
+1. `webflow_guide_tool` → `data_sites_tool` → list current scripts
+2. Warn: removes ALL scripts. Require "delete all" → `delete_all_site_scripts`
+3. Verify and remind to publish
 
-**User:** "Remove all custom scripts from my site"
-
-1. Call `webflow_guide_tool` for best practices
-2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `data_scripts_tool` with `list_registered_scripts` to show what will be deleted
-4. Warn: "This will remove ALL scripts — there is no selective delete. Type **delete all** to confirm."
-5. After confirmation: call `data_scripts_tool` with `delete_all_site_scripts`
-6. Verify by re-listing scripts
-7. Remind user to publish
-
-### Example 4: Add a chat widget script
-
-**User:** "Add an Intercom chat widget to my site"
-
-1. Call `webflow_guide_tool` for best practices
-2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Ask user for their Intercom app ID
-4. Present plan with script preview and character count
-5. After "add" confirmation: call `data_scripts_tool` with `add_inline_site_script`:
-   - displayName: "Intercom Chat Widget"
-   - sourceCode: Intercom initialization snippet
-   - version: "1.0.0"
-   - location: "footer"
-   - canCopy: false
-6. Verify and remind user to publish
-
-### Example 5: Add page-specific tracking
-
+### Example 4: Page-specific tracking
 **User:** "Add conversion tracking to my thank-you page"
-
-1. Call `webflow_guide_tool` for best practices
-2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `data_scripts_tool` with `get_page_script` to check existing page scripts
-4. Present plan: "I'll add conversion tracking code to the thank-you page. Type **update** to confirm."
-5. After confirmation: call `data_scripts_tool` with `upsert_page_script`
-6. Verify by calling `get_page_script` again
-7. Remind user to publish
+1. `webflow_guide_tool` → `data_sites_tool` → `get_page_script` to check existing
+2. Preview, require "update" → `upsert_page_script`
+3. Verify and remind to publish
 
 ## Guidelines
 
-### Script Content Rules
-- Maximum 10,000 characters per script
-- Do NOT include `<script>` tags — Webflow adds them automatically
-- `displayName` + `version` must be unique per site
-- Use semantic version numbers (e.g., "1.0.0", "2.1.0")
-- Use descriptive display names (e.g., "Google Tag Manager", not "GTM")
-
-### Confirmation Requirements
-- **Adding scripts**: Require user to type "add"
-- **Deleting ALL site scripts**: Require user to type "delete all"
-- **Updating page scripts**: Require user to type "update"
-- Do NOT accept generic confirmations ("yes", "ok", "go") for destructive operations
-- Always show a preview of the script content before adding
-
-### Scope Awareness
-- Site-level scripts (`add_inline_site_script`) apply to all pages
-- Page-level scripts (`upsert_page_script`) apply to a specific page only
-- `delete_all_site_scripts` removes ALL site-level scripts — no selective delete available
-- `delete_all_page_scripts` removes all scripts from a specific page
-- Hosted/external scripts are not available via MCP — only inline scripts
-
-### Safety and Best Practices
-- Always list existing scripts before adding new ones to avoid duplicates
-- Warn users about the destructive nature of `delete_all_site_scripts`
-- Remind users to publish after any script changes
-- Suggest using the `safe-publish` skill for publishing
-- For analytics scripts (GA, GTM), recommend header placement
-- For chat widgets and non-critical scripts, recommend footer placement
-- Validate script content doesn't contain malicious patterns
-
-### Error Handling
-- If `displayName + version` already exists, suggest incrementing the version
-- If script exceeds 10,000 chars, suggest splitting or hosting externally
-- If site has no scripts to delete, inform user — don't call delete
+- **`webflow_guide_tool` always first** — before any other MCP tool
+- **No `<script>` tags** — Webflow adds them automatically
+- **Max 10,000 characters** per script; `displayName` + `version` must be unique
+- **Site-level** scripts (`add_inline_site_script`) apply to all pages; **page-level** scripts (`upsert_page_script`) apply to one page
+- **No selective delete** — `delete_all_site_scripts` removes everything; always list scripts first so user knows what will be lost
+- **Hosted/external scripts** not available via MCP — inline only
+- Recommend **header** for analytics (GA, GTM); **footer** for chat widgets and non-critical scripts
+- If `displayName + version` exists, suggest incrementing the version
+- Always remind users to **publish** after changes


### PR DESCRIPTION
## Summary

Rewrite of the `custom-code-management` skill — the most underdeveloped skill in the repo (~50 lines, missing required sections). Now ~90 lines with full coverage.

## What was wrong

- Missing `webflow_guide_tool` (only MCP skill without it)
- No `## Examples` section (required by CONTRIBUTING.md)
- No `## Guidelines` section (required by CONTRIBUTING.md)
- No phased workflow (flat numbered steps)
- Missing page-level script operations (`get_page_script`, `upsert_page_script`, `delete_all_page_scripts`)
- Original incorrectly stated "Site-level only (no page-specific via MCP)" — the MCP does support page-level scripts
- Inconsistent header casing (`## Important note` → `## Important Note`)

## All original guidance preserved

| Original guidance | Status in rewrite |
|---|---|
| `register (store) → apply (attach)` concept | Covered in Phase 2 (registration vs application status) |
| `list_registered_scripts` / `list_applied_scripts` | Important Note + Phase 2 |
| `add_inline_site_script` with displayName, sourceCode, version, location, canCopy | Phase 4 step 6 |
| `delete_all_site_scripts` — no selective delete | Multiple warnings in Planning + Guidelines |
| Max 10,000 chars per script | Important Note + Guidelines |
| No `<script>` tags (Webflow adds them) | Important Note + Guidelines |
| `displayName + version` must be unique | Guidelines |
| Hosted scripts not available via MCP | Guidelines |
| Require "add" to confirm adding | Phase 3 |
| Require "delete all" to confirm removal | Phase 3 |
| Remind user to publish / suggest safe-publish | Phase 5 + Guidelines |

## What's new

- `webflow_guide_tool` as first step
- 5-phase workflow: Discovery → Analysis → Planning → Execution → Verification
- 4 examples: view scripts, add GTM, remove all, page-specific tracking
- Page-level operations: `get_page_script`, `upsert_page_script`, `delete_all_page_scripts`
- Explicit confirmation gates with specific keywords
- Header vs footer placement recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)