### PR TITLE
docs(DEVPL-4732): skill-authoring guidance with CONTRIBUTING.md as source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,4 +60,4 @@ Optional frontmatter: `license`, `model`, `allowed-tools`
 
 ## Adding/Editing Skills
 
-Follow `CONTRIBUTING.md`. PR title format: `feat(skills): Add [skill-name]`. Keep SKILL.md under 500 lines. Every skill needs Instructions, Examples, and Guidelines sections.
+Before authoring or editing a skill, read `CONTRIBUTING.md` — especially **Designing skills (start here)**, which links Anthropic's skill-design guide and the `skill-creator` skill. PR title format: `feat(skills): Add [skill-name]`. Keep SKILL.md under 500 lines. Every skill needs Instructions, Examples, and Guidelines sections.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,15 @@
 # Contributing
 
-Guidelines for adding and improving Webflow skills.
+Guidelines for adding and improving Webflow skills. Internal and external contributions are both welcome.
+
+## Designing skills (start here)
+
+New to writing skills? Use Anthropic's guidance and tooling before you start — it's the fastest way to get a skill right the first time:
+
+- **[The Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)** — how to scope, structure, and name a skill, write descriptions with strong trigger keywords, apply progressive disclosure, and include effective examples.
+- **[`skill-creator` skill](https://github.com/anthropics/skills/blob/main/skills/skill-creator)** — install it and let it scaffold and refine your `SKILL.md` instead of starting from a blank file.
+
+Then follow the structure and conventions below.
 
 ## Adding a New Skill
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ All skills ship from the single `webflow-skills` plugin.
 - [Available Tools](https://developers.webflow.com/mcp/v1.0.0/reference/how-it-works#available-tools) - Complete tool reference
 - [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) - Learn about the Agent Skills standard
 
+## Contributing
+
+Internal and external contributions are both welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) — it covers how to design a skill (Anthropic's skill-design guide + the `skill-creator` skill), the `SKILL.md` structure and conventions, and the pull request process.
+
 ## License
 
 MIT


### PR DESCRIPTION
JIRA: https://webflow.atlassian.net/browse/DEVPL-4732

## Why

Make it easy for **both internal and external** contributors to build skills correctly, and cut the recurring "how do I write a skill?" churn. Codifies the guidance Virat shared in the #webflow-skills thread (Anthropic's *Complete Guide to Building Skills for Claude* + the `skill-creator` skill) into the repo.

## Approach — one source of truth, reached from every surface

- **CONTRIBUTING.md** (canonical): new **"Designing skills (start here)"** section — human-facing and GitHub-surfaced, so it reaches external contributors who never open agent config files.
- **CLAUDE.md** (the real file; `AGENTS.md` symlinks to it): a thin pointer to that section so agents route to the same doc — no duplicated content to drift.
- **README.md**: new **Contributing** section linking CONTRIBUTING.md (the README had no contributing link at all — the main external discoverability gap).

Substance lives in one place; the agent path and the README front door both point to it.

## Notes
- Edited `CLAUDE.md` only; `AGENTS.md` stays a symlink (CI requires it), so both stay in sync automatically.
- Docs-only; no skills added or changed. CI here is structural (required files + SKILL.md frontmatter), unaffected.
- Filed under DEVPL pending a clearer Scale Pillar project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)