### PR TITLE
feat(skills): add webflow-mcp:figma-to-webflow skill for translating Figma designs into Webflow projects and update version numbers to 1.0.7

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Production-ready agent skills for Webflow - CMS management, site auditing, Designer tools, Code Components, CLI workflows, and safe publishing",
   "author": {
     "name": "Webflow",
@@ -20,6 +20,8 @@
     "asset-optimization",
     "designer",
     "designer-tools",
+    "figma",
+    "figma-to-webflow",
     "components",
     "code-components",
     "cli",

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All skills ship from the single `webflow-skills` plugin.
 | webflow-mcp:custom-code-management | Manage tracking scripts and custom code safely |
 | webflow-mcp:flowkit-naming | Apply Webflow's official FlowKit CSS naming conventions |
 | webflow-mcp:designer-tools | Build and manage page structure, elements, components, and styles in Webflow Designer |
+| webflow-mcp:figma-to-webflow | Build pages, sections, components, or full sites from Figma designs using Figma MCP and Webflow MCP |
 
 ### Webflow CLI Skills
 

--- a/plugins/webflow-skills/.claude-plugin/plugin.json
+++ b/plugins/webflow-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "skills": "./skills/"
 }

--- a/plugins/webflow-skills/.codex-plugin/plugin.json
+++ b/plugins/webflow-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes.",
   "author": {
     "name": "Webflow",
@@ -24,6 +24,8 @@
     "designer-tools",
     "components",
     "code-components",
+    "figma",
+    "figma-to-webflow",
     "cli",
     "devlink",
     "webflow-cloud",
@@ -48,6 +50,7 @@
       "Find and fix broken links on my site",
       "Prepare a safe publish checklist",
       "Inspect the current Designer page structure",
+      "Build this Figma design in Webflow",
       "Create a new Webflow Code Component",
       "Deploy a Webflow Cloud app"
     ],

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -31,6 +31,7 @@ and explain the tradeoff instead of silently substituting.
 - **Vector gate:** logos, icons, and marks must be inline SVG embeds, not PNG/JPG uploads, unless the user explicitly approves raster fallback.
 - **Raster quality gate:** hero/product/mockup images must use a confirmed 2x source where crispness matters.
 - **Dashed accent gate:** dashed lines, dividers, grids, accents, and underlines must use `repeating-linear-gradient`, not `border-style:dashed`, unless the user explicitly accepts browser-default dash rhythm.
+- **Navbar gate:** custom navbar mobile behavior must be CSS-only, not JavaScript. Use the checkbox/sibling-selector pattern in `references/navbar.md`.
 - **Publish gate:** do not publish by default. Offer `.webflow.io` publish only after build/review, and only proceed on explicit user confirmation.
 
 ## Tool Surfaces
@@ -62,55 +63,14 @@ and explain the tradeoff instead of silently substituting.
 
 ### Required Prompts
 
-Before creating Webflow variables, classes, or CSS, ask about build mode, design-system strategy, naming, and units.
+Before creating Webflow variables, classes, or CSS, ask these four questions:
 
-**Build-mode prompt:**
+- **Build mode:** Designer Bridge during build (default, better visual QA; requires Designer tab open/foregrounded) or headless first (faster, structural checks only until bridge needed).
+- **Variables/design system:** read existing variables and create missing ones (default), create a new design system from scratch, use existing variables only, or hard-code with no Webflow variables.
+- **Style naming:** FlowKit naming (default; reference `webflow-mcp:flowkit-naming`), existing Webflow design-system naming, or clear semantic kebab-case names.
+- **Units:** `px` (default), `rem`, or `em`. Keep units consistent; only mix when there is a clear reason.
 
-> Do you want me to build headless, or use the Webflow Designer Bridge app during the build?
-
-Offer these choices, with Designer Bridge selected as the default:
-
-1. **Use the Designer Bridge during the build (default)** — better feedback loop and visual confidence. The agent can take snapshots, inspect the canvas/page state, confirm layering/composition earlier, and catch visual issues while building. Requires the Webflow Designer tab to be open, connected, and kept in the foreground; if the tab is backgrounded or idle, bridge tools can disconnect or return `status:false`.
-2. **Build headless first** — fastest and least interruptive. Use `data_*` tools for DOM, styles, variables, fonts, assets, pages, scripts, responsive overrides, and structural verification; ask for the bridge only if visual QA or image processing needs it.
-
-If the user does not choose, default to **use the Designer Bridge during the build**. Share or request the Designer launch link and remind them to keep the tab foregrounded while bridge tools run.
-
-**Design-system prompt:**
-
-> How should I handle Webflow variables for this build?
-
-Offer these choices, with "read existing variables and create missing ones" selected as the recommended default for existing sites:
-
-1. **Read existing variables and create missing ones (recommended)** — inspect current Webflow variables first, map Figma tokens to existing variables when possible, and create only the missing colors, typography, spacing, and radius variables needed for the design.
-2. **Create a new design system from scratch** — create a fresh variable set from the Figma design's colors, typography, spacing, and radii before building sections. Best for blank/new sites or isolated experiments.
-3. **Use existing variables only** — inspect and use only variables that already exist in Webflow. If a Figma token has no match, ask before hard-coding or changing the design.
-4. **Do not use Webflow variables** — hard-code values in the generated styles. Use only when the user explicitly chooses speed or one-off output over maintainability.
-
-If the user does not choose, default to **read existing variables and create missing ones**. For a brand-new/blank site, recommend **create a new design system from scratch** and explain why before proceeding.
-
-**Naming prompt:**
-
-> Do you want to use FlowKit naming conventions for new styles?
-
-Offer these choices, with FlowKit selected as the recommended default:
-
-1. **Yes, use FlowKit naming (recommended)** — follow the `webflow-mcp:flowkit-naming` skill when creating new styles. Use FlowKit patterns such as `fk-[component]`, `fk-[component]-[element]`, utility classes like `fk-section` / `fk-container`, and combo-state classes like `is-active`.
-2. **Use the existing Webflow design system if one exists** — inspect existing classes/styles first, reuse the site's established tokens and naming patterns, and only introduce new names that fit that system.
-3. **Use clear semantic names for this build** — create layout/structure-based kebab-case names that are easy to maintain, without forcing FlowKit if the site does not use it.
-
-If the user does not choose, default to **FlowKit naming**. Never mix naming strategies casually within the same build; if an established site system conflicts with FlowKit, call out the tradeoff and ask before proceeding.
-
-**Unit prompt:**
-
-> Do you want this build to use px, rem, or em units?
-
-Offer these choices, with px selected as the default:
-
-1. **px (default)** — match Figma/Webflow values directly and avoid conversion drift.
-2. **rem** — use scalable root-relative units for typography and spacing where practical.
-3. **em** — use component-relative units where the design intentionally scales with local font size.
-
-If the user does not choose, default to **px**. Keep units consistent within a build; only mix units when there is a clear reason, such as `%` for fluid widths or `em` for icon/text relationships.
+If the user does not choose, use the defaults above. For a blank site, recommend creating a new design system from scratch and explain why.
 
 ### 2. Build Foundations And Sections
 
@@ -139,7 +99,7 @@ If the build includes a navbar, read [Navbar](references/navbar.md) before build
 
 - Ask which breakpoint should collapse to hamburger.
 - Webflow native Navbar cannot be created via API/WHTML. Build a semantic custom nav or ask the user to add the native element in Designer.
-- Put component behavior `<style>`/`<script>` in an HtmlEmbed inside the component root. Use site/page head code only for truly global behavior.
+- Put CSS-only component behavior in an HtmlEmbed inside the component root. Do not use JavaScript for the custom navbar.
 
 ### 5. Responsive And QA
 
@@ -151,40 +111,6 @@ Before responsive/final verification, read [Verification](references/verificatio
 4. Do not trust first snapshots for fonts; warm cache and re-snapshot before changing font implementation.
 5. Do not claim embed behavior, custom code, blur, WebGL, animation, or mobile widths are verified from your side. Ask the user to confirm in preview/published site.
 6. Offer publish/review next steps. Default remains **no publish**.
-
-## Examples
-
-### Example 1: Build a Figma frame into a Webflow page
-
-**User:** "Build this Figma frame in my Webflow site: [figma.com URL]"
-
-1. Use Figma MCP to gather metadata, design context, variables, screenshots, and export URLs for the requested frame.
-2. Use Webflow MCP to call `webflow_guide_tool`, confirm the user/site/page, and inspect existing styles.
-3. Ask whether to use Designer Bridge during the build or build headless first; explain the bridge is recommended for visual feedback but requires the Designer tab open and foregrounded.
-4. Ask how to handle Webflow variables, whether to use FlowKit naming / existing class patterns / semantic names, and whether to use `px`, `rem`, or `em` units.
-5. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
-6. Confirm the build gates: Designer link/foreground tab if using bridge, SVG embeds for vector marks, 2× raster sources where needed, and gradient-based dashed accents.
-7. Read the referenced files at their point of use, set up or map variables, build DOM with `data_whtml_builder`, style with `data_style_tool`, attach assets by Webflow asset ID, verify, then ask whether they want to publish to `.webflow.io`. Default to no.
-
-### Example 2: Recreate a Figma section in an existing Webflow page
-
-**User:** "Recreate this pricing section from Figma on my homepage."
-
-1. Extract the section's Figma tokens, assets, and reference code.
-2. Confirm the target Webflow site/page and ask whether to use the default Designer Bridge flow or build headless first.
-3. Confirm build mode plus variable, naming, and unit strategy before generating new Webflow classes/CSS; default to Designer Bridge, existing variables plus missing variables, FlowKit, and `px` if the user has no preference.
-4. Present a concise preview plan that calls out the non-negotiable build gates, then require explicit confirmation before creating elements.
-5. Insert one section, constrain confirmed 2× images to display size, verify structurally headless or visually with bridge snapshots if selected, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
-
-## Guidelines
-
-- Always use Figma MCP for design extraction and Webflow MCP for Webflow operations; never use direct Webflow API calls.
-- Call `webflow_guide_tool` before other Webflow tools in the workflow.
-- Ask for build mode, Webflow variable, style naming, and CSS unit strategy before creating classes. Default to Designer Bridge, existing variables plus missing variables, FlowKit naming, and `px`; reference `webflow-mcp:flowkit-naming` when FlowKit is selected.
-- Treat mutating Webflow operations as confirmation-gated. Require explicit user approval before creating, updating, publishing, or deleting.
-- Prefer `data_whtml_builder` for DOM/section construction, then `data_style_tool` for all styling and element tools for precise asset binding, embeds, and refinements.
-- Keep CSS Webflow-compatible. Only non-native CSS belongs in Custom properties.
-- Do not publish by default. If the user wants a live review link, publish to the `.webflow.io` subdomain before any custom domains.
 
 ## Checklist before declaring done
 

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -25,18 +25,20 @@ Webflow MCP has **two kinds of tools with different requirements**:
 
 | Surface | Examples | Needs Designer open? |
 |---|---|---|
-| **Data API** (headless) | pages, sites, scripts, fonts, asset *metadata*, publish | No |
-| **Designer Bridge** | image upload, element create/edit/move/query, snapshots, styles | **Yes — Designer tab open AND foregrounded** |
+| **Data API** (headless) | `data_whtml_builder`, `data_element_builder`, `data_element_tool`, `data_style_tool`, `data_fonts_tool`, `data_pages_tool`, `data_scripts_tool`, `data_assets_tool`, publish | No |
+| **Designer Bridge** | `element_snapshot_tool`, `designer_tool` canvas/selection/navigation, `asset_tool upload_image_by_url` | **Yes — Designer tab open AND foregrounded** |
 
 - Call `webflow_guide_tool` once before other Webflow tools. Confirm auth/site with `whoami` + `get_site`.
-- If a Designer tool returns "Unable to connect to Webflow Designer," share the launch link and ask the user to open the Designer **and keep that browser tab in the foreground** — it idles/disconnects when backgrounded. Snapshots especially fail (`status:false`) when unfocused; retry before assuming anything broke.
+- Prefer bridge-assisted builds by default for better visual feedback, while still using `data_*` tools for DOM, classes/styles, text, semantic tags, responsive overrides, fonts, scripts, pages, and asset records.
+- If Designer is disconnected, continue structural work headlessly with `query_styles`, `get_all_elements`, and `query_elements`; reconnect the bridge for snapshots, canvas inspection, and any still-required bridge-gated image processing fallback.
+- If a bridge tool returns `status:false` or "Unable to connect to Webflow Designer," share the launch link and ask the user to open the Designer **and keep that browser tab in the foreground** — it idles/disconnects when backgrounded. Retry before assuming anything broke.
 
 ### 1. Workflow order
 
 1. **Gather** — Figma structure, tokens, per-section code/colors/assets; Webflow site, pages, existing styles.
-2. **Choose style preferences** — ask how Webflow variables, new styles, and CSS units should be handled before creating any classes/CSS (see §3).
+2. **Choose build mode and style preferences** — ask whether to build headless or bridge-assisted, then ask how Webflow variables, new styles, and CSS units should be handled before creating any classes/CSS (see §3).
 3. **Set up foundations** — Webflow variables/design tokens, page wrapper w/ base typography, and fonts.
-4. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify after each.
+4. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify structurally after each, and visually if the user chose bridge-assisted mode.
 5. **Attach assets** (images by ID; inline SVGs via embeds).
 6. **Responsive pass** (desktop-first overrides).
 7. **Custom code / interactions** last (mobile menu, animated backgrounds, blur).
@@ -47,14 +49,26 @@ Confirm ambiguous design intent up front (e.g., a button whose label is a repeat
 ### 2. Extracting from Figma
 
 - `get_metadata` → node/structure map. `get_design_context` per node → reference code + exact colors + asset download URLs + a screenshot. `get_variable_defs` → design tokens (colors, type scale, spacing, radii). Pull tokens early and treat them as law.
+- Read the page/canvas background color from Figma; do not assume white. Set the real page background on `.page-wrapper`, or white cards/sections can disappear against the wrong background.
 - **Asset URLs from design-context live ~7 days; `get_screenshot` URLs are short-lived** — upload promptly.
 - **Vector assets (logos, icons, marks): use `download_assets` with `defaultFormat: "svg"`** — NOT `get_screenshot`. Screenshot only rasterizes and **never upscales past the node's native size** (so it can't give you 2×, and it bakes in surrounding background).
   - **Gotcha:** the SVG export wraps the node in its ancestor chain and **bakes in background fills** clipped to the node box (page background rect, card background, a node "backing" rect). Strip the full-bleed background `<rect>`/`<path>` elements that aren't part of the target → clean transparent vector. (Remaining `fill="white"` inside `<defs><clipPath>` are just clip masks — leave them.)
-- **Raster (photos, complex product mockups): can't get 2× from `get_screenshot`.** Use the design-context layer export URLs (often already 2×) or composite the 2× image locally, then upload (see §5, §6).
+- **Raster (photos, complex product mockups): can't get 2× from `get_screenshot`.** Use the design-context layer export URLs (often already 2×) or `download_assets` at 2× for a composed parent node; treat layered product mockups as one image instead of reconstructing every layer (see §5, §6).
 
-### 3. Style preferences
+### 3. Build mode and style preferences
 
-Before creating Webflow variables, classes, or CSS, ask about design-system strategy, naming, and units.
+Before creating Webflow variables, classes, or CSS, ask about build mode, design-system strategy, naming, and units.
+
+**Build-mode prompt:**
+
+> Do you want me to build headless, or use the Webflow Designer Bridge app during the build?
+
+Offer these choices, with Designer Bridge selected as the default:
+
+1. **Use the Designer Bridge during the build (default)** — better feedback loop and visual confidence. The agent can take snapshots, inspect the canvas/page state, confirm layering/composition earlier, and catch visual issues while building. Requires the Webflow Designer tab to be open, connected, and kept in the foreground; if the tab is backgrounded or idle, bridge tools can disconnect or return `status:false`.
+2. **Build headless first** — fastest and least interruptive. Use `data_*` tools for DOM, styles, variables, fonts, assets, pages, scripts, responsive overrides, and structural verification; ask for the bridge only if visual QA or image processing needs it.
+
+If the user does not choose, default to **use the Designer Bridge during the build**. Share or request the Designer launch link and remind them to keep the tab foregrounded while bridge tools run.
 
 **Design-system prompt:**
 
@@ -126,8 +140,9 @@ Use the headless Data API asset path first. Do **not** rely on `asset_tool uploa
   - The presigned **policy is base64 — validate it is pure ASCII** before POSTing (`grep '[^A-Za-z0-9+/=]'`); transcription homoglyphs cause a 403.
   - Append the file field last in the multipart POST.
 - **Verify processing before placing the image.** Fetch/check the created asset after upload. If it remains `size:0` or has no variants, tell the user the upload succeeded but Webflow has not processed a renderable asset yet.
-- **Bridge-gated fallback:** if processed variants are required and `create_asset` does not process them, ask the user to open and foreground Webflow Designer before using any bridge-gated asset processing fallback. Do not assume `upload_image_by_url` will remain available.
+- **Bridge-gated fallback:** if processed variants are required and `create_asset` does not process them, raise the issue rather than reverting silently. If a fallback is still available, ask the user to open and foreground Webflow Designer. Do not assume `upload_image_by_url` will remain available.
 - **`whtml <img src="...">` does NOT link to the asset library by URL** ("inserted without a managed asset"). After inserting, `query_elements` for the `Image` and `set_image_asset` by asset ID.
+- Bind images by asset ID with `set_image_asset`, or create the Image with `data_element_builder` and `set_image_asset` in the same step when possible. Apply an image-fill class (`width:100%; height:100%; object-fit:cover; display:block`) inside the image's container/placeholder.
 - **hiDPI/retina:** Webflow's HiDPI checkbox is Designer-UI-only. Equivalent via API: ship a **2× source and let CSS constrain it to its display width** → crisp automatically.
 - Delete orphaned `size:0` assets to keep the library clean.
 
@@ -135,18 +150,25 @@ Use the headless Data API asset path first. Do **not** rely on `asset_tool uploa
 
 - **An SVG uploaded as an asset and placed via `<img>` can render as a filled blob** when it has gradients/complex fills. **Inline the SVG inside an `HtmlEmbed`** for crisp, transparent, recolorable vectors.
 - **Setting embed code:** create the `HtmlEmbed` (code can't be set at creation), then `data_element_tool set_settings` with key `"code"` and the raw markup as `static_text`.
+- To avoid malformed tool-call JSON, single-quote SVG attributes, optimize before transcribing, collapse whitespace, round path coordinates to ~1 decimal, and do one SVG per call. Around 13 KB is usually reliable; 16–20 KB is risky.
+- Strip Figma SVG export noise: full-page/canvas backing rects, dashed component-boundary rects, off-target paths, and unused `id` attributes. Keep ids referenced by `url(#...)` gradients/clips and leave `fill="white"` inside `<defs><clipPath>` alone.
+- Crop the SVG `viewBox` to the artwork bounds and put `style="height:Npx; width:auto; display:block"` on the root `<svg>` when sizing by height. If the export is too messy, ask the user to paste Figma's cleaner "Copy as SVG" output.
+- Regex gotcha when parsing SVG: `id="X"` contains `d="X"` as a substring. Match `\sd="` with a leading boundary, not bare `d="`.
 - Dark-background variant: duplicate the SVG and swap wordmark `fill` hex to white (leave `fill="url(#…)"` gradient fills alone).
 - **`set_text("")` on a Link wipes its child embeds.** Never clear a link's text after inserting an icon embed (or re-add the embed after).
 - For multiple logos of different proportions, **crop each SVG `viewBox` to its content bounds** so you can size them uniformly in a flex row.
 
 ### 8. Fonts (`data_fonts_tool`)
 
-- `create_font` (`file_hash` = MD5 of the woff2) → presigned upload → POST the bytes. Source woff2 from the Google Fonts `css2` endpoint (latin subset) with a desktop User-Agent.
-- Custom fonts resolve by **exact family name** referenced in your CSS once published — then you can remove any temporary Google Fonts `<head>` link.
+- Upload fonts with `data_fonts_tool`: `create_font` (`file_hash` = MD5 of the woff2) → presigned upload → POST the bytes. Source woff2 from the Google Fonts `css2` endpoint (latin subset) with a desktop User-Agent when needed.
+- Never add Google Fonts `<link>` tags to page/site `<head>` after uploading fonts; they create duplicate `@font-face` declarations. Reference fonts by **exact family name** in CSS.
+- First snapshots can show fallback fonts during the cold-cache `font-display: swap` window. Warm the cache with a throwaway/full-page snapshot and re-snapshot before "fixing" fonts. Do not add head links to solve snapshot-only fallback fonts.
+- Variable-font woff2 files can serve multiple weights; registering each weight against the same source file is acceptable.
 
 ### 9. Custom code & interactions
 
-- **Prefer `data_scripts_tool set_site_freeform_code` (head/footer) for `<style>`/`<script>`.** The *registered-script* apply endpoints (`add_site_script`/`add_page_script`) may 404 depending on the site; freeform code is reliable.
+- **Prefer component-scoped HtmlEmbeds for component behavior** (e.g., navbar mobile-toggle CSS/JS) so the behavior travels if the element becomes a Webflow component. Create the embed inside the component root, then set code via `data_element_tool set_settings`.
+- Use `data_scripts_tool set_site_freeform_code` (head/footer) only for genuinely global `<style>`/`<script>`. The *registered-script* apply endpoints (`add_site_script`/`add_page_script`) may 404 depending on the site; freeform code is reliable.
 - **Unused combo classes get stripped from published CSS.** A class you only toggle at runtime via JS (e.g., `.menu.is-open`) has **no matching rule** unless you (a) apply the combo to an element in the Designer, or (b) **guarantee the rule in a head `<style>`**. This silently makes JS toggles do nothing.
 - **HTML embed + `<style>`/`<script>` is the escape hatch** for anything Webflow's panel can't express: parent-state→child selectors, custom mobile-menu toggle, or any CSS/JS Webflow strips or can't model.
 - **Native components (Navbar, etc.) cannot be created via API/whtml** — whtml just produces generic blocks with `w-*` class names (no real component JS/CSS). Either build a custom equivalent (+ a small delegated-click script) or have the user add the native element in the Designer.
@@ -209,19 +231,37 @@ Keep all **desktop visual styling** (colors, padding, link/burger-bar look) as n
 
 ### 12. Verification & its hard limits
 
-- `element_snapshot_tool`: Designer-foreground only; **desktop viewport only (no responsive/mobile simulation)**; **does not execute embeds / WebGL / `backdrop-filter`** (those render only on the published/preview site). An isolated-section snapshot renders transparent areas as **black** — not a bug.
+- `element_snapshot_tool`: Designer-foreground only; **desktop viewport only (no responsive/mobile simulation)**; **does not execute embeds / WebGL / `backdrop-filter`** (those render only on the published/preview site).
+- Isolated-section snapshots do not include sibling overlays (e.g., page-level grids/backgrounds). Verify overlays/layering with a full-page composite snapshot of the top-level wrapper.
+- Transparent regions render as **black** in isolated snapshots; on the page they show the page background. `position:fixed` elements can render unreliably in composites; verify clearance on preview/live.
+- First snapshot of a session can show fallback fonts; warm the cache and re-snapshot before changing font implementation.
 - You **cannot fetch `*.webflow.io`** (robots-blocked) or run JS on it. So:
   - If the user chooses to publish to the subdomain, ask them to confirm anything you can't see in the Designer — embed behavior, custom-code, mobile/responsive widths. Never claim an embed is verified from your side.
 
 ### 13. Layout patterns worth reusing
 
 - **Background grid lines:** `repeating-linear-gradient` for dashes (control dash/gap precisely — a CSS dashed *border* can't). Give each line element a **real width (≥1px)** so Webflow doesn't flag it as an empty/clickable zero-width element. Place at `z-index:-1` inside a stacking-context wrapper so it sits behind content but above the page background.
+- Use `repeating-linear-gradient`, not `border-style:dashed`, for dashed accents/dividers/underlines so dash length, gap, opacity, and direction match the design rhythm.
+- Decorative overlays must sit behind content. Make `.page-wrapper` a stacking context (`position:relative; z-index:0`) and place overlays at `z-index:-1`; opaque cards then hide the overlay while gutters show it.
+- Never use a fixed overlay width wider than the viewport. Prefer `left:0; right:0; width:auto; max-width:<design-width>; margin-left:auto; margin-right:auto`.
+- Replicate interior grid lines too, not just outer edges; check Figma for distributed columns (e.g., 25/50/75%).
 - **Perceived weight ≠ literal alpha:** lines *behind* content read lighter than identical lines *in front* (occlusion). Match the perceived weight when pairing them.
 - **Section dividers:** use a thin absolutely-positioned gradient-line element to match a dashed grid's rhythm, not a dashed `border`.
 - **Fixed vs sticky nav:** `fixed` lets the first section sit *under* the bar (useful when the nav is translucent/overlays content); then add top-padding to that section to clear the bar. `sticky` reserves space (content starts below the bar).
 - **Replacing an `<img>` with an embed loses the img's classes/margins** — reapply spacing on the embed.
 
-### 14. Reference: local-file upload (presigned S3)
+### 14. Build mechanics & gotchas
+
+- `data_whtml_builder` requires a single root element per action. To insert multiple sibling sections, use multiple actions.
+- `set_style` replaces all classes on an element. If a class does not exist yet, create it with `data_style_tool create_style` or define it in the WHTML CSS param so Webflow creates it.
+- `query_elements` style filters are case-insensitive substring matches; filter returned elements by exact class/type before acting.
+- Responsive work is headless: use `data_style_tool update_style` with breakpoint IDs (`main` base, then `medium`, `small`, `tiny`). Desktop-first: set base, override downward.
+- Capture returned element ids from every insert. Re-find later by exact style/type when possible. Element ids are `{component, element}`, where `component` is the page id.
+- Combo classes (`["base","modifier"]`) can be ambiguous. When in doubt, prefer one standalone class with full styling.
+- Figma component instances often carry repeated placeholder labels (e.g., identical button text). Confirm intended labels with the user instead of copying placeholders verbatim.
+- Suppress Designer-only `.wf-empty` affordances on decorative empty elements by giving normal DivBlocks a dimension-giving style in the active breakpoint (explicit zero padding works). For custom-tag empty elements, add a child or use a normal DivBlock instead.
+
+### 15. Reference: local-file upload (presigned S3)
 
 ```bash
 # 1) Download/export the image locally and compute MD5 of the bytes.
@@ -246,25 +286,26 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 1. Use Figma MCP to gather metadata, design context, variables, screenshots, and export URLs for the requested frame.
 2. Use Webflow MCP to call `webflow_guide_tool`, confirm the user/site/page, and inspect existing styles.
-3. Ask how to handle Webflow variables, whether to use FlowKit naming / existing class patterns / semantic names, and whether to use `px`, `rem`, or `em` units.
-4. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
-5. Set up or map variables according to the selected design-system strategy, build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
+3. Ask whether to use Designer Bridge during the build or build headless first; explain the bridge is recommended for visual feedback but requires the Designer tab open and foregrounded.
+4. Ask how to handle Webflow variables, whether to use FlowKit naming / existing class patterns / semantic names, and whether to use `px`, `rem`, or `em` units.
+5. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
+6. Set up or map variables according to the selected design-system strategy, build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
 
 ### Example 2: Recreate a Figma section in an existing Webflow page
 
 **User:** "Recreate this pricing section from Figma on my homepage."
 
 1. Extract the section's Figma tokens, assets, and reference code.
-2. Confirm the target Webflow site/page and Designer connection.
-3. Confirm variable, naming, and unit strategy before generating new Webflow classes/CSS; default to existing variables plus missing variables, FlowKit, and `px` if the user has no preference.
+2. Confirm the target Webflow site/page. Designer connection is only needed later for snapshot/visual QA or bridge-gated fallbacks.
+3. Confirm build mode plus variable, naming, and unit strategy before generating new Webflow classes/CSS; default to Designer Bridge, existing variables plus missing variables, FlowKit, and `px` if the user has no preference.
 4. Present a concise preview plan and require explicit confirmation before creating elements.
-5. Insert one section, constrain images with 2× sources where needed, verify with Designer snapshots, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
+5. Insert one section, constrain images with 2× sources where needed, verify structurally headless or visually with bridge snapshots if selected, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
 
 ## Guidelines
 
 - Always use Figma MCP for design extraction and Webflow MCP for Webflow operations; never use direct Webflow API calls.
 - Call `webflow_guide_tool` before other Webflow tools in the workflow.
-- Ask for Webflow variable, style naming, and CSS unit strategy before creating classes. Default to existing variables plus missing variables, FlowKit naming, and `px`; reference `webflow-mcp:flowkit-naming` when FlowKit is selected.
+- Ask for build mode, Webflow variable, style naming, and CSS unit strategy before creating classes. Default to Designer Bridge, existing variables plus missing variables, FlowKit naming, and `px`; reference `webflow-mcp:flowkit-naming` when FlowKit is selected.
 - Treat mutating Webflow operations as confirmation-gated. Require explicit user approval before creating, updating, publishing, or deleting.
 - Prefer `data_whtml_builder` for section construction, then use element tools for precise asset binding, embeds, and refinements.
 - Keep CSS Webflow-compatible: longhand properties, class selectors, desktop-first breakpoints, flexbox-first layout, and custom code for unsupported behavior.
@@ -273,6 +314,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 ## Checklist before declaring done
 
 - [ ] All CSS longhand; correct breakpoints; flexbox-first.
+- [ ] Build mode followed: bridge-assisted by default with Designer tab open and foregrounded, or headless-first if the user chose it.
 - [ ] Webflow variables handled according to the selected strategy; repeated colors/type/spacing/radii are mapped or created unless hard-coding was explicitly selected.
 - [ ] Images attached by asset ID (not orphan `<img src>`); 2× where crispness matters.
 - [ ] Vector marks are clean inline-SVG embeds (backgrounds stripped).

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: webflow-mcp:figma-to-webflow
+description: >-
+  Build a Webflow page, section, component, or full site from a Figma design
+  using the Figma MCP and the Webflow MCP (Designer Bridge + Data API). Use
+  whenever translating a Figma file/frame into Webflow, building directly in a
+  Webflow project, or implementing a design as live Webflow elements/styles
+  (not a copy-paste fragment). Triggers: "build this Figma in Webflow",
+  "Figma to Webflow", "implement this design in Webflow", a figma.com URL +
+  a Webflow site, "recreate this in my Webflow project".
+---
+
+# Figma → Webflow
+
+Translate a Figma design into a live Webflow project: real elements, styles,
+assets, fonts, and (optionally) custom code + interactions. This skill is the
+hard-won playbook — follow the order, and heed the gotchas (each is something
+that silently fails or wastes a publish cycle if you don't know it).
+
+## Instructions
+
+### 0. The single most important thing: two tool surfaces
+
+Webflow MCP has **two kinds of tools with different requirements**:
+
+| Surface | Examples | Needs Designer open? |
+|---|---|---|
+| **Data API** (headless) | pages, sites, scripts, fonts, asset *metadata*, publish | No |
+| **Designer Bridge** | image upload, element create/edit/move/query, snapshots, styles | **Yes — Designer tab open AND foregrounded** |
+
+- Call `webflow_guide_tool` once before other Webflow tools. Confirm auth/site with `whoami` + `get_site`.
+- If a Designer tool returns "Unable to connect to Webflow Designer," share the launch link and ask the user to open the Designer **and keep that browser tab in the foreground** — it idles/disconnects when backgrounded. Snapshots especially fail (`status:false`) when unfocused; retry before assuming anything broke.
+
+### 1. Workflow order
+
+1. **Gather** — Figma structure, tokens, per-section code/colors/assets; Webflow site, pages, existing styles.
+2. **Set up foundations** — page wrapper w/ base typography; design tokens; fonts.
+3. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify after each.
+4. **Attach assets** (images by ID; inline SVGs via embeds).
+5. **Responsive pass** (desktop-first overrides).
+6. **Custom code / interactions** last (mobile menu, animated backgrounds, blur).
+7. **Publish to the `.webflow.io` subdomain** for the user to review; iterate.
+
+Confirm ambiguous design intent up front (e.g., a button whose label is a repeated component placeholder) rather than guessing. **If the build includes a navbar, ask which breakpoint the mobile menu should collapse at before building it (see §9).**
+
+### 2. Extracting from Figma
+
+- `get_metadata` → node/structure map. `get_design_context` per node → reference code + exact colors + asset download URLs + a screenshot. `get_variable_defs` → design tokens (colors, type scale, spacing, radii). Pull tokens early and treat them as law.
+- **Asset URLs from design-context live ~7 days; `get_screenshot` URLs are short-lived** — upload promptly.
+- **Vector assets (logos, icons, marks): use `download_assets` with `defaultFormat: "svg"`** — NOT `get_screenshot`. Screenshot only rasterizes and **never upscales past the node's native size** (so it can't give you 2×, and it bakes in surrounding background).
+  - **Gotcha:** the SVG export wraps the node in its ancestor chain and **bakes in background fills** clipped to the node box (page background rect, card background, a node "backing" rect). Strip the full-bleed background `<rect>`/`<path>` elements that aren't part of the target → clean transparent vector. (Remaining `fill="white"` inside `<defs><clipPath>` are just clip masks — leave them.)
+- **Raster (photos, complex product mockups): can't get 2× from `get_screenshot`.** Use the design-context layer export URLs (often already 2×) or composite the 2× image locally, then upload (see §4, §7).
+
+### 3. Webflow CSS rules (these bite)
+
+- **Longhand only.** Expand `padding`, `margin`, `border`, `border-radius` (4 corners), `font`, `background`, `transition`, `flex`.
+- **Class selectors only.** No tag/ID/descendant/attribute selectors. `:hover` is the only safe pseudo-class; no `::before`/`::after` (use real elements).
+- **Gaps:** emit `grid-row-gap` / `grid-column-gap` even on flex (Webflow's stored keys) — not `row-gap`/`column-gap`.
+- **Desktop-first breakpoints (Webflow).** Override downward only; WHTML media queries need the `screen and` prefix (e.g., `@media screen and (max-width: 767px)`).
+  - **Desktop (base)** — applies to all devices unless overridden at another breakpoint.
+  - **Tablet** — screens **991px** and below.
+  - **Mobile landscape** — screens **767px** and below.
+  - **Mobile portrait** — screens **479px** and below.
+- **Flexbox-first**; grid only for true 2D.
+- **Forbidden / dropped:** `calc()`, `clamp()`, `min()/max()`, `@keyframes`, `@font-face`, multi-layer `box-shadow`, logical props, vendor prefixes. For animation use IX2 or a custom-code embed.
+- Put inheritable typography (font-family, color, base size/line-height) once on `.page-wrapper`; single font names, no fallback stacks.
+- Naming: layout/structure-based, kebab-case; never page-prefixed.
+
+### 4. Building elements
+
+- **`data_whtml_builder` is the workhorse** — pass HTML + raw CSS; class selectors become real Webflow styles automatically. Build one section per call, set `return_element_info:true`, and use the returned id as the parent for the next insert.
+- **Element identity & page context:** an element id is `{component, element}` where **`component` IS the page id**. `data_element_tool` actions must run with the **matching top-level `pageId`** — a mismatch returns "Element not found." This is exactly how you target a *duplicated* page's elements (pass that page's id).
+- `data_element_builder` (typed elements, supports `set_style`/`set_image_asset`/children at creation) is the fallback when you need precise control; component instances need `component_builder`.
+- Keep nesting ≤4–5 levels.
+
+### 5. Images & assets
+
+Two upload paths:
+
+- **Public URL → `asset_tool upload_image_by_url`.** Works for a Figma asset URL or any reachable CDN URL; **fully processes the asset (variants)** so it renders. This is the easy path.
+- **Local file → 3 steps:** `data_assets_tool create_asset` (with `file_hash` = MD5 of the bytes) → `curl` POST the bytes to the returned **presigned S3 form** → **then re-ingest via `upload_image_by_url` on the resulting CDN URL.** Skipping the re-ingest leaves the asset at `size:0` / no variants, and **the Designer won't render it.**
+  - The presigned **policy is base64 — validate it is pure ASCII** before POSTing (`grep '[^A-Za-z0-9+/=]'`); transcription homoglyphs cause a 403.
+- **`whtml <img src="...">` does NOT link to the asset library by URL** ("inserted without a managed asset"). After inserting, `query_elements` for the `Image` and `set_image_asset` by asset ID.
+- **hiDPI/retina:** Webflow's HiDPI checkbox is Designer-UI-only. Equivalent via API: ship a **2× source and let CSS constrain it to its display width** → crisp automatically.
+- Delete orphaned `size:0` assets to keep the library clean.
+
+### 6. SVG, logos, icons → use embeds
+
+- **An SVG uploaded as an asset and placed via `<img>` can render as a filled blob** when it has gradients/complex fills. **Inline the SVG inside an `HtmlEmbed`** for crisp, transparent, recolorable vectors.
+- **Setting embed code:** create the `HtmlEmbed` (code can't be set at creation), then `data_element_tool set_settings` with key `"code"` and the raw markup as `static_text`.
+- Dark-background variant: duplicate the SVG and swap wordmark `fill` hex to white (leave `fill="url(#…)"` gradient fills alone).
+- **`set_text("")` on a Link wipes its child embeds.** Never clear a link's text after inserting an icon embed (or re-add the embed after).
+- For multiple logos of different proportions, **crop each SVG `viewBox` to its content bounds** so you can size them uniformly in a flex row.
+
+### 7. Fonts (`data_fonts_tool`)
+
+- `create_font` (`file_hash` = MD5 of the woff2) → presigned upload → POST the bytes. Source woff2 from the Google Fonts `css2` endpoint (latin subset) with a desktop User-Agent.
+- Custom fonts resolve by **exact family name** referenced in your CSS once published — then you can remove any temporary Google Fonts `<head>` link.
+
+### 8. Custom code & interactions
+
+- **Prefer `data_scripts_tool set_site_freeform_code` (head/footer) for `<style>`/`<script>`.** The *registered-script* apply endpoints (`add_site_script`/`add_page_script`) may 404 depending on the site; freeform code is reliable.
+- **Unused combo classes get stripped from published CSS.** A class you only toggle at runtime via JS (e.g., `.menu.is-open`) has **no matching rule** unless you (a) apply the combo to an element in the Designer, or (b) **guarantee the rule in a head `<style>`**. This silently makes JS toggles do nothing.
+- **HTML embed + `<style>`/`<script>` is the escape hatch** for anything Webflow's panel can't express: parent-state→child selectors, custom mobile-menu toggle, or any CSS/JS Webflow strips or can't model.
+- **Native components (Navbar, etc.) cannot be created via API/whtml** — whtml just produces generic blocks with `w-*` class names (no real component JS/CSS). Either build a custom equivalent (+ a small delegated-click script) or have the user add the native element in the Designer.
+
+### 9. Navbar (reusable recipe)
+
+Webflow's native Navbar component can't be created via the API/whtml (whtml only yields generic blocks), yet most sites need one. Build a **semantic `<nav>` from Webflow custom elements** + a **CSS-only mobile toggle in a code embed** — no JS, no native component.
+
+**Always ask first:** *which breakpoint should the menu collapse to a hamburger?* Then recommend based on the design, and use their answer as `{BP}`:
+- **≤3–4 short links, no/short CTA** → Mobile landscape (**767**) or Mobile portrait (**479**) — they stay readable longer.
+- **5+ links, long labels, or a prominent CTA** → Tablet (**991**) — collapse earlier so the bar never crowds.
+- State your recommendation with the reason, then defer to their choice.
+
+**Structure** — build with custom tags (`set_tag` / `BY_CUSTOM_TAG`) so it's semantic and Designer-editable:
+
+```html
+<nav class="nav">                         ← custom element, tag = nav; position: relative (or sticky/fixed)
+  <div class="nav-inner">                 ← flex row, space-between, max-width container
+    <a class="nav-brand" href="/">…logo…</a>
+    <input type="checkbox" id="nav-toggle" class="nav-cb">   ← custom tag "input", attr type=checkbox
+    <label for="nav-toggle" class="nav-burger">              ← custom tag "label", attr for=nav-toggle
+      <span class="nav-burger-bar"></span> ×3
+    </label>
+    <div class="nav-menu">                 ← links + CTA (real, editable Webflow links)
+      <a class="nav-link" href="#">…</a> …
+      <a class="btn" href="#">CTA</a>
+    </div>
+  </div>
+</nav>
+```
+
+**Critical:** the checkbox must be a **previous sibling** of `.nav-menu` (order: brand → checkbox → burger → menu) so `:checked ~ .nav-menu` resolves. Make `.nav` (or `.nav-inner`) `position: relative` so the dropdown anchors to the bar. Use custom-tag `input`/`label` (not the Form Checkbox element) to avoid Webflow's `.w-checkbox` wrapper, which would break the sibling chain.
+
+**Behavior — one code embed, CSS only** (replace `{BP}` with the chosen breakpoint). This CSS uses `:checked ~` + a media query that Webflow's style panel can't express — which is exactly why it lives in an embed:
+
+```html
+<style>
+  .nav-cb{ position:absolute; width:1px; height:1px; opacity:0; pointer-events:none; }  /* a11y-hidden toggle */
+  .nav-burger{ display:none; }                       /* hidden on desktop */
+  @media screen and (max-width:{BP}px){
+    .nav-burger{ display:flex; flex-direction:column; row-gap:5px; cursor:pointer; }
+    .nav-menu{
+      display:none; position:absolute; top:100%; left:0; right:0;
+      flex-direction:column; align-items:flex-start; row-gap:4px;
+      padding:16px 24px; background:#fff; box-shadow:0 10px 24px rgba(0,0,0,.10);
+    }
+    .nav-cb:checked ~ .nav-menu{ display:flex; }      /* pure-CSS open/close */
+  }
+</style>
+```
+
+Keep all **desktop visual styling** (colors, padding, link/burger-bar look) as normal Webflow classes; the embed holds only the responsive + toggle **behavior**.
+
+**Tradeoffs:** the pure-CSS toggle is zero-JS and publish-safe, but doesn't set `aria-expanded` or close on outside-click. If the client needs those, swap the embed for a small JS toggle (delegated click + class toggle) — but a JS-toggled class needs its open-state rule **guaranteed in custom code** (an unused combo class is stripped from published CSS — see §8). Optionally animate the bars to an "X" via `.nav-cb:checked ~ .nav-burger` rules inside the same embed.
+
+### 10. Isolating experiments / "branching"
+
+- **Page-branching API may be unavailable** (`create_branch`/`list_branches` → 404). Substitute: **`create_page` with `duplicateOf`** to clone the page as an experiment "branch" (gets its own page id; target its elements with that `pageId`). Revert main by deleting the experimental elements.
+- For reversible enhancements, **layer the new thing over a static fallback** (e.g., an animated canvas over the static gradient image) rather than replacing it.
+
+### 11. Verification & its hard limits
+
+- `element_snapshot_tool`: Designer-foreground only; **desktop viewport only (no responsive/mobile simulation)**; **does not execute embeds / WebGL / `backdrop-filter`** (those render only on the published/preview site). An isolated-section snapshot renders transparent areas as **black** — not a bug.
+- You **cannot fetch `*.webflow.io`** (robots-blocked) or run JS on it. So:
+  - **Publish to the subdomain and ask the user to confirm** anything you can't see in the Designer — embed behavior, custom-code, mobile/responsive widths. Never claim an embed is verified from your side.
+
+### 12. Layout patterns worth reusing
+
+- **Background grid lines:** `repeating-linear-gradient` for dashes (control dash/gap precisely — a CSS dashed *border* can't). Give each line element a **real width (≥1px)** so Webflow doesn't flag it as an empty/clickable zero-width element. Place at `z-index:-1` inside a stacking-context wrapper so it sits behind content but above the page background.
+- **Perceived weight ≠ literal alpha:** lines *behind* content read lighter than identical lines *in front* (occlusion). Match the perceived weight when pairing them.
+- **Section dividers:** use a thin absolutely-positioned gradient-line element to match a dashed grid's rhythm, not a dashed `border`.
+- **Fixed vs sticky nav:** `fixed` lets the first section sit *under* the bar (useful when the nav is translucent/overlays content); then add top-padding to that section to clear the bar. `sticky` reserves space (content starts below the bar).
+- **Replacing an `<img>` with an embed loses the img's classes/margins** — reapply spacing on the embed.
+
+### 13. Reference: local-file upload (presigned S3)
+
+```bash
+# 1) create_asset returns uploadUrl + uploadDetails (presigned form) + hostedUrl
+# 2) POST the bytes (field order: form fields first, file LAST):
+curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
+  -F "key=$KEY" -F "acl=public-read" -F "Content-Type=image/png" \
+  -F "cache-control=max-age=31536000" -F "success_action_status=201" \
+  -F "X-Amz-Algorithm=..." -F "X-Amz-Credential=..." -F "X-Amz-Date=..." \
+  -F "X-Amz-Signature=$SIG" -F "policy=$POLICY" -F "bucket=..." \
+  -F "file=@/path/to/image.png"
+# 3) then upload_image_by_url on the returned hostedUrl  → processed asset that renders
+```
+
+> Validate `$POLICY` is pure base64 ASCII before sending: `printf '%s' "$POLICY" | grep -q '[^A-Za-z0-9+/=]' && echo "ABORT: non-ASCII in policy"`.
+
+## Examples
+
+### Example 1: Build a Figma frame into a Webflow page
+
+**User:** "Build this Figma frame in my Webflow site: [figma.com URL]"
+
+1. Use Figma MCP to gather metadata, design context, variables, screenshots, and export URLs for the requested frame.
+2. Use Webflow MCP to call `webflow_guide_tool`, confirm the user/site/page, and inspect existing styles.
+3. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
+4. Build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then publish to the `.webflow.io` subdomain for review.
+
+### Example 2: Recreate a Figma section in an existing Webflow page
+
+**User:** "Recreate this pricing section from Figma on my homepage."
+
+1. Extract the section's Figma tokens, assets, and reference code.
+2. Confirm the target Webflow site/page and Designer connection.
+3. Present a concise preview plan and require explicit confirmation before creating elements.
+4. Insert one section, constrain images with 2× sources where needed, verify with Designer snapshots, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
+
+## Guidelines
+
+- Always use Figma MCP for design extraction and Webflow MCP for Webflow operations; never use direct Webflow API calls.
+- Call `webflow_guide_tool` before other Webflow tools in the workflow.
+- Treat mutating Webflow operations as confirmation-gated. Require explicit user approval before creating, updating, publishing, or deleting.
+- Prefer `data_whtml_builder` for section construction, then use element tools for precise asset binding, embeds, and refinements.
+- Keep CSS Webflow-compatible: longhand properties, class selectors, desktop-first breakpoints, flexbox-first layout, and custom code for unsupported behavior.
+- Publish to the `.webflow.io` subdomain for review before custom domains unless the user explicitly asks otherwise.
+
+## Checklist before declaring done
+
+- [ ] All CSS longhand; correct breakpoints; flexbox-first.
+- [ ] Images attached by asset ID (not orphan `<img src>`); 2× where crispness matters.
+- [ ] Vector marks are clean inline-SVG embeds (backgrounds stripped).
+- [ ] Fonts uploaded + referenced by exact family name; temp `<head>` link removed.
+- [ ] Runtime-toggled classes have guaranteed CSS (not stripped).
+- [ ] Responsive overrides at medium/small/tiny.
+- [ ] Published to subdomain; user asked to confirm anything you can't self-verify (embeds, WebGL, blur, mobile).

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -44,6 +44,15 @@ Webflow MCP has **two kinds of tools with different requirements**:
 7. **Custom code / interactions** last (mobile menu, animated backgrounds, blur).
 8. **Offer review/publish next steps** — default to **no publish**. Only publish to the `.webflow.io` subdomain if the user explicitly asks or confirms after reviewing the build.
 
+### Speed defaults
+
+- Build in section-sized batches with `data_whtml_builder`; avoid element-by-element construction unless precision requires it.
+- Create variables/classes for common primitives once (containers, typography, spacing, buttons, image-fill, cards, nav) and reuse them aggressively.
+- Snapshot groups/wrappers, not every element. Prefer structural verification with `query_elements` / `query_styles` between visual checks.
+- Export complex layered visuals as 2× composed images instead of rebuilding every layer in Webflow.
+- Gather Figma metadata, variables, and major-section design context up front; avoid repeated per-node Figma calls for small children.
+- If using Designer Bridge, keep the tab foregrounded and batch several headless `data_*` operations between bridge snapshots.
+
 Confirm ambiguous design intent up front (e.g., a button whose label is a repeated component placeholder) rather than guessing. **If the build includes a navbar, ask which breakpoint the mobile menu should collapse at before building it (see §10).**
 
 ### 2. Extracting from Figma

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -34,14 +34,15 @@ Webflow MCP has **two kinds of tools with different requirements**:
 ### 1. Workflow order
 
 1. **Gather** — Figma structure, tokens, per-section code/colors/assets; Webflow site, pages, existing styles.
-2. **Set up foundations** — page wrapper w/ base typography; design tokens; fonts.
-3. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify after each.
-4. **Attach assets** (images by ID; inline SVGs via embeds).
-5. **Responsive pass** (desktop-first overrides).
-6. **Custom code / interactions** last (mobile menu, animated backgrounds, blur).
-7. **Publish to the `.webflow.io` subdomain** for the user to review; iterate.
+2. **Choose naming strategy** — ask how new Webflow styles should be named before creating any classes (see §3).
+3. **Set up foundations** — page wrapper w/ base typography; design tokens; fonts.
+4. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify after each.
+5. **Attach assets** (images by ID; inline SVGs via embeds).
+6. **Responsive pass** (desktop-first overrides).
+7. **Custom code / interactions** last (mobile menu, animated backgrounds, blur).
+8. **Offer review/publish next steps** — default to **no publish**. Only publish to the `.webflow.io` subdomain if the user explicitly asks or confirms after reviewing the build.
 
-Confirm ambiguous design intent up front (e.g., a button whose label is a repeated component placeholder) rather than guessing. **If the build includes a navbar, ask which breakpoint the mobile menu should collapse at before building it (see §9).**
+Confirm ambiguous design intent up front (e.g., a button whose label is a repeated component placeholder) rather than guessing. **If the build includes a navbar, ask which breakpoint the mobile menu should collapse at before building it (see §10).**
 
 ### 2. Extracting from Figma
 
@@ -49,9 +50,23 @@ Confirm ambiguous design intent up front (e.g., a button whose label is a repeat
 - **Asset URLs from design-context live ~7 days; `get_screenshot` URLs are short-lived** — upload promptly.
 - **Vector assets (logos, icons, marks): use `download_assets` with `defaultFormat: "svg"`** — NOT `get_screenshot`. Screenshot only rasterizes and **never upscales past the node's native size** (so it can't give you 2×, and it bakes in surrounding background).
   - **Gotcha:** the SVG export wraps the node in its ancestor chain and **bakes in background fills** clipped to the node box (page background rect, card background, a node "backing" rect). Strip the full-bleed background `<rect>`/`<path>` elements that aren't part of the target → clean transparent vector. (Remaining `fill="white"` inside `<defs><clipPath>` are just clip masks — leave them.)
-- **Raster (photos, complex product mockups): can't get 2× from `get_screenshot`.** Use the design-context layer export URLs (often already 2×) or composite the 2× image locally, then upload (see §4, §7).
+- **Raster (photos, complex product mockups): can't get 2× from `get_screenshot`.** Use the design-context layer export URLs (often already 2×) or composite the 2× image locally, then upload (see §5, §6).
 
-### 3. Webflow CSS rules (these bite)
+### 3. Naming new Webflow styles
+
+Before creating new classes, ask:
+
+> Do you want to use FlowKit naming conventions for new styles?
+
+Offer these choices, with FlowKit selected as the recommended default:
+
+1. **Yes, use FlowKit naming (recommended)** — follow the `webflow-mcp:flowkit-naming` skill when creating new styles. Use FlowKit patterns such as `fk-[component]`, `fk-[component]-[element]`, utility classes like `fk-section` / `fk-container`, and combo-state classes like `is-active`.
+2. **Use the existing Webflow design system if one exists** — inspect existing classes/styles first, reuse the site's established tokens and naming patterns, and only introduce new names that fit that system.
+3. **Use clear semantic names for this build** — create layout/structure-based kebab-case names that are easy to maintain, without forcing FlowKit if the site does not use it.
+
+If the user does not choose, default to **FlowKit naming**. Never mix naming strategies casually within the same build; if an established site system conflicts with FlowKit, call out the tradeoff and ask before proceeding.
+
+### 4. Webflow CSS rules (these bite)
 
 - **Longhand only.** Expand `padding`, `margin`, `border`, `border-radius` (4 corners), `font`, `background`, `transition`, `flex`.
 - **Class selectors only.** No tag/ID/descendant/attribute selectors. `:hover` is the only safe pseudo-class; no `::before`/`::after` (use real elements).
@@ -64,16 +79,16 @@ Confirm ambiguous design intent up front (e.g., a button whose label is a repeat
 - **Flexbox-first**; grid only for true 2D.
 - **Forbidden / dropped:** `calc()`, `clamp()`, `min()/max()`, `@keyframes`, `@font-face`, multi-layer `box-shadow`, logical props, vendor prefixes. For animation use IX2 or a custom-code embed.
 - Put inheritable typography (font-family, color, base size/line-height) once on `.page-wrapper`; single font names, no fallback stacks.
-- Naming: layout/structure-based, kebab-case; never page-prefixed.
+- Naming: follow the selected naming strategy. If using FlowKit, reference `webflow-mcp:flowkit-naming`; otherwise use layout/structure-based, kebab-case names and never page-prefixed names.
 
-### 4. Building elements
+### 5. Building elements
 
 - **`data_whtml_builder` is the workhorse** — pass HTML + raw CSS; class selectors become real Webflow styles automatically. Build one section per call, set `return_element_info:true`, and use the returned id as the parent for the next insert.
 - **Element identity & page context:** an element id is `{component, element}` where **`component` IS the page id**. `data_element_tool` actions must run with the **matching top-level `pageId`** — a mismatch returns "Element not found." This is exactly how you target a *duplicated* page's elements (pass that page's id).
 - `data_element_builder` (typed elements, supports `set_style`/`set_image_asset`/children at creation) is the fallback when you need precise control; component instances need `component_builder`.
 - Keep nesting ≤4–5 levels.
 
-### 5. Images & assets
+### 6. Images & assets
 
 Two upload paths:
 
@@ -84,7 +99,7 @@ Two upload paths:
 - **hiDPI/retina:** Webflow's HiDPI checkbox is Designer-UI-only. Equivalent via API: ship a **2× source and let CSS constrain it to its display width** → crisp automatically.
 - Delete orphaned `size:0` assets to keep the library clean.
 
-### 6. SVG, logos, icons → use embeds
+### 7. SVG, logos, icons → use embeds
 
 - **An SVG uploaded as an asset and placed via `<img>` can render as a filled blob** when it has gradients/complex fills. **Inline the SVG inside an `HtmlEmbed`** for crisp, transparent, recolorable vectors.
 - **Setting embed code:** create the `HtmlEmbed` (code can't be set at creation), then `data_element_tool set_settings` with key `"code"` and the raw markup as `static_text`.
@@ -92,19 +107,19 @@ Two upload paths:
 - **`set_text("")` on a Link wipes its child embeds.** Never clear a link's text after inserting an icon embed (or re-add the embed after).
 - For multiple logos of different proportions, **crop each SVG `viewBox` to its content bounds** so you can size them uniformly in a flex row.
 
-### 7. Fonts (`data_fonts_tool`)
+### 8. Fonts (`data_fonts_tool`)
 
 - `create_font` (`file_hash` = MD5 of the woff2) → presigned upload → POST the bytes. Source woff2 from the Google Fonts `css2` endpoint (latin subset) with a desktop User-Agent.
 - Custom fonts resolve by **exact family name** referenced in your CSS once published — then you can remove any temporary Google Fonts `<head>` link.
 
-### 8. Custom code & interactions
+### 9. Custom code & interactions
 
 - **Prefer `data_scripts_tool set_site_freeform_code` (head/footer) for `<style>`/`<script>`.** The *registered-script* apply endpoints (`add_site_script`/`add_page_script`) may 404 depending on the site; freeform code is reliable.
 - **Unused combo classes get stripped from published CSS.** A class you only toggle at runtime via JS (e.g., `.menu.is-open`) has **no matching rule** unless you (a) apply the combo to an element in the Designer, or (b) **guarantee the rule in a head `<style>`**. This silently makes JS toggles do nothing.
 - **HTML embed + `<style>`/`<script>` is the escape hatch** for anything Webflow's panel can't express: parent-state→child selectors, custom mobile-menu toggle, or any CSS/JS Webflow strips or can't model.
 - **Native components (Navbar, etc.) cannot be created via API/whtml** — whtml just produces generic blocks with `w-*` class names (no real component JS/CSS). Either build a custom equivalent (+ a small delegated-click script) or have the user add the native element in the Designer.
 
-### 9. Navbar (reusable recipe)
+### 10. Navbar (reusable recipe)
 
 Webflow's native Navbar component can't be created via the API/whtml (whtml only yields generic blocks), yet most sites need one. Build a **semantic `<nav>` from Webflow custom elements** + a **CSS-only mobile toggle in a code embed** — no JS, no native component.
 
@@ -153,20 +168,20 @@ Webflow's native Navbar component can't be created via the API/whtml (whtml only
 
 Keep all **desktop visual styling** (colors, padding, link/burger-bar look) as normal Webflow classes; the embed holds only the responsive + toggle **behavior**.
 
-**Tradeoffs:** the pure-CSS toggle is zero-JS and publish-safe, but doesn't set `aria-expanded` or close on outside-click. If the client needs those, swap the embed for a small JS toggle (delegated click + class toggle) — but a JS-toggled class needs its open-state rule **guaranteed in custom code** (an unused combo class is stripped from published CSS — see §8). Optionally animate the bars to an "X" via `.nav-cb:checked ~ .nav-burger` rules inside the same embed.
+**Tradeoffs:** the pure-CSS toggle is zero-JS and publish-safe, but doesn't set `aria-expanded` or close on outside-click. If the client needs those, swap the embed for a small JS toggle (delegated click + class toggle) — but a JS-toggled class needs its open-state rule **guaranteed in custom code** (an unused combo class is stripped from published CSS — see §9). Optionally animate the bars to an "X" via `.nav-cb:checked ~ .nav-burger` rules inside the same embed.
 
-### 10. Isolating experiments / "branching"
+### 11. Isolating experiments / "branching"
 
 - **Page-branching API may be unavailable** (`create_branch`/`list_branches` → 404). Substitute: **`create_page` with `duplicateOf`** to clone the page as an experiment "branch" (gets its own page id; target its elements with that `pageId`). Revert main by deleting the experimental elements.
 - For reversible enhancements, **layer the new thing over a static fallback** (e.g., an animated canvas over the static gradient image) rather than replacing it.
 
-### 11. Verification & its hard limits
+### 12. Verification & its hard limits
 
 - `element_snapshot_tool`: Designer-foreground only; **desktop viewport only (no responsive/mobile simulation)**; **does not execute embeds / WebGL / `backdrop-filter`** (those render only on the published/preview site). An isolated-section snapshot renders transparent areas as **black** — not a bug.
 - You **cannot fetch `*.webflow.io`** (robots-blocked) or run JS on it. So:
-  - **Publish to the subdomain and ask the user to confirm** anything you can't see in the Designer — embed behavior, custom-code, mobile/responsive widths. Never claim an embed is verified from your side.
+  - If the user chooses to publish to the subdomain, ask them to confirm anything you can't see in the Designer — embed behavior, custom-code, mobile/responsive widths. Never claim an embed is verified from your side.
 
-### 12. Layout patterns worth reusing
+### 13. Layout patterns worth reusing
 
 - **Background grid lines:** `repeating-linear-gradient` for dashes (control dash/gap precisely — a CSS dashed *border* can't). Give each line element a **real width (≥1px)** so Webflow doesn't flag it as an empty/clickable zero-width element. Place at `z-index:-1` inside a stacking-context wrapper so it sits behind content but above the page background.
 - **Perceived weight ≠ literal alpha:** lines *behind* content read lighter than identical lines *in front* (occlusion). Match the perceived weight when pairing them.
@@ -174,7 +189,7 @@ Keep all **desktop visual styling** (colors, padding, link/burger-bar look) as n
 - **Fixed vs sticky nav:** `fixed` lets the first section sit *under* the bar (useful when the nav is translucent/overlays content); then add top-padding to that section to clear the bar. `sticky` reserves space (content starts below the bar).
 - **Replacing an `<img>` with an embed loses the img's classes/margins** — reapply spacing on the embed.
 
-### 13. Reference: local-file upload (presigned S3)
+### 14. Reference: local-file upload (presigned S3)
 
 ```bash
 # 1) create_asset returns uploadUrl + uploadDetails (presigned form) + hostedUrl
@@ -198,8 +213,9 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 1. Use Figma MCP to gather metadata, design context, variables, screenshots, and export URLs for the requested frame.
 2. Use Webflow MCP to call `webflow_guide_tool`, confirm the user/site/page, and inspect existing styles.
-3. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
-4. Build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then publish to the `.webflow.io` subdomain for review.
+3. Ask whether to use FlowKit naming, the existing Webflow design system, or clear semantic names for this build.
+4. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
+5. Build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
 
 ### Example 2: Recreate a Figma section in an existing Webflow page
 
@@ -207,17 +223,19 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 1. Extract the section's Figma tokens, assets, and reference code.
 2. Confirm the target Webflow site/page and Designer connection.
-3. Present a concise preview plan and require explicit confirmation before creating elements.
-4. Insert one section, constrain images with 2× sources where needed, verify with Designer snapshots, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
+3. Confirm the naming strategy before generating new Webflow classes; default to FlowKit if the user has no preference.
+4. Present a concise preview plan and require explicit confirmation before creating elements.
+5. Insert one section, constrain images with 2× sources where needed, verify with Designer snapshots, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
 
 ## Guidelines
 
 - Always use Figma MCP for design extraction and Webflow MCP for Webflow operations; never use direct Webflow API calls.
 - Call `webflow_guide_tool` before other Webflow tools in the workflow.
+- Ask for a style naming strategy before creating classes. Default to FlowKit and reference `webflow-mcp:flowkit-naming` when that option is selected.
 - Treat mutating Webflow operations as confirmation-gated. Require explicit user approval before creating, updating, publishing, or deleting.
 - Prefer `data_whtml_builder` for section construction, then use element tools for precise asset binding, embeds, and refinements.
 - Keep CSS Webflow-compatible: longhand properties, class selectors, desktop-first breakpoints, flexbox-first layout, and custom code for unsupported behavior.
-- Publish to the `.webflow.io` subdomain for review before custom domains unless the user explicitly asks otherwise.
+- Do not publish by default. If the user wants a live review link, publish to the `.webflow.io` subdomain before any custom domains.
 
 ## Checklist before declaring done
 
@@ -227,4 +245,4 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 - [ ] Fonts uploaded + referenced by exact family name; temp `<head>` link removed.
 - [ ] Runtime-toggled classes have guaranteed CSS (not stripped).
 - [ ] Responsive overrides at medium/small/tiny.
-- [ ] Published to subdomain; user asked to confirm anything you can't self-verify (embeds, WebGL, blur, mobile).
+- [ ] If published to subdomain, user asked to confirm anything you can't self-verify (embeds, WebGL, blur, mobile).

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -27,11 +27,15 @@ and explain the tradeoff instead of silently substituting.
 
 - **Bridge gate:** Designer Bridge is the default build mode. If selected, provide or request the Designer launch link and wait for the user to open the project with the Designer tab foregrounded before bridge-dependent steps. If the bridge disconnects, keep structural work headless and reconnect before snapshots/canvas inspection.
 - **Native style gate:** apply styles with `data_style_tool`, never with the `data_whtml_builder` `css` param or raw `var()` strings. Otherwise styles land in Custom properties instead of native controls. Bind Webflow variables with `variable_as_value`.
+- **Visible element gate:** build with real Designer-visible elements and native classes. Do not use embed `<style>` blocks, `::before` / `::after`, or other hidden constructs for normal layout/decorative elements.
+- **Class existence gate:** create every class with `data_style_tool create_style` before using it in WHTML/element class lists. Webflow can silently drop class names that do not exist yet.
 - **Variables gate:** decide the Webflow variable/design-system strategy before creating styles. Do not hard-code repeated colors/type/spacing/radii unless the user explicitly chooses hard-coded output.
 - **Vector gate:** logos, icons, and marks must be inline SVG embeds, not PNG/JPG uploads, unless the user explicitly approves raster fallback.
 - **Raster quality gate:** hero/product/mockup images must use a confirmed 2x source where crispness matters.
 - **Dashed accent gate:** dashed lines, dividers, grids, accents, and underlines must use `repeating-linear-gradient`, not `border-style:dashed`, unless the user explicitly accepts browser-default dash rhythm.
 - **Navbar gate:** custom navbar mobile behavior must be CSS-only, not JavaScript. Use the checkbox/sibling-selector pattern in `references/navbar.md`.
+- **Verification gate:** never call a build done until you have verified rendered output. If visual verification is blocked, say what is unverified and ask the user to check it.
+- **Capability gate:** do not assert that Webflow or MCP "can't" do something until you have tested the relevant tool path or clearly label it as untested.
 - **Publish gate:** do not publish by default. Offer `.webflow.io` publish only after build/review, and only proceed on explicit user confirmation.
 
 ## Tool Surfaces
@@ -78,10 +82,11 @@ Before creating variables/classes/styles, read [CSS rules](references/css-rules.
 
 1. Create or map Webflow variables according to the selected strategy.
 2. Create reusable primitives first: page wrapper, containers, typography, spacing, buttons, image-fill, cards, nav.
-3. Use `data_whtml_builder` for DOM/structure only: one root section per action, semantic tags, nesting, text, and class names.
-4. Create styles with `data_style_tool create_style` / `update_style`. Repeat: do **not** use the WHTML `css` param for styling.
-5. Capture returned element ids. Re-find later with `query_elements`, then filter by exact class/type before acting.
-6. Build in section-sized batches. Prefer structural verification with `query_elements` / `query_styles` between visual checks.
+3. Create needed classes with `data_style_tool create_style` before referencing them in WHTML/element class lists.
+4. Use `data_whtml_builder` for DOM/structure only: one root section per action, semantic tags, nesting, text, and existing class names.
+5. Style with `data_style_tool update_style`. Repeat: do **not** use the WHTML `css` param or embed `<style>` blocks for normal styling.
+6. Capture returned element ids. Re-find later with `query_elements`, then filter by exact class/type before acting.
+7. Build in section-sized batches. Prefer structural verification with `query_elements` / `query_styles` between visual checks.
 
 ### 3. Attach Assets
 
@@ -109,14 +114,17 @@ Before responsive/final verification, read [Verification](references/verificatio
 2. If Designer Bridge is selected, snapshot groups/wrappers rather than every element. Keep the Designer tab foregrounded.
 3. Verify overlays/layering with a full-page composite, not isolated-section snapshots.
 4. Do not trust first snapshots for fonts; warm cache and re-snapshot before changing font implementation.
-5. Do not claim embed behavior, custom code, blur, WebGL, animation, or mobile widths are verified from your side. Ask the user to confirm in preview/published site.
-6. Offer publish/review next steps. Default remains **no publish**.
+5. Test tool capabilities before asserting limitations. If you cannot test, say "untested" and describe the uncertainty.
+6. Do not claim embed behavior, custom code, blur, WebGL, animation, or mobile widths are verified from your side. Ask the user to confirm in preview/published site.
+7. Offer publish/review next steps. Default remains **no publish**.
 
 ## Checklist before declaring done
 
 - [ ] Required reference files were read at their point of use.
 - [ ] All CSS longhand; correct breakpoints; flexbox-first.
 - [ ] Styles applied via `data_style_tool` (native controls), variables bound with `variable_as_value`, and only truly non-native CSS (`backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient`, etc.) left as custom properties.
+- [ ] All class names used in WHTML/element class lists exist as Webflow styles; none were silently dropped.
+- [ ] No embed `<style>` blocks or `::before` / `::after` pseudo-elements used for normal layout/decorative elements.
 - [ ] Build mode followed: bridge-assisted by default with Designer tab open and foregrounded, or headless-first if the user chose it.
 - [ ] Webflow variables handled according to the selected strategy; repeated colors/type/spacing/radii are mapped or created unless hard-coding was explicitly selected.
 - [ ] Images attached by asset ID (not orphan `<img src>`); 2× source confirmed where crispness matters.
@@ -125,4 +133,6 @@ Before responsive/final verification, read [Verification](references/verificatio
 - [ ] Fonts uploaded + referenced by exact family name; temp `<head>` link removed.
 - [ ] Runtime-toggled classes have guaranteed CSS (not stripped).
 - [ ] Responsive overrides at medium/small/tiny.
+- [ ] Rendered output verified visually, or unverified items clearly reported to the user.
+- [ ] No untested capability limitation was stated as fact.
 - [ ] If published to subdomain, user asked to confirm anything you can't self-verify (embeds, WebGL, blur, mobile).

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -44,6 +44,15 @@ Webflow MCP has **two kinds of tools with different requirements**:
 7. **Custom code / interactions** last (mobile menu, animated backgrounds, blur).
 8. **Offer review/publish next steps** — default to **no publish**. Only publish to the `.webflow.io` subdomain if the user explicitly asks or confirms after reviewing the build.
 
+### Non-negotiable build gates
+
+Treat these as gates, not suggestions. Before building, explicitly confirm the planned choice for each item; if you cannot satisfy one, stop and explain the tradeoff instead of silently substituting.
+
+- **Bridge gate:** if the user chooses Designer Bridge (the default), provide/request the Designer launch link and wait for the user to open the project with the Designer tab foregrounded before running bridge-dependent steps. Do not skip this setup and start building as if headless were selected.
+- **Vector gate:** logos, icons, and marks must be inline SVG embeds, not PNG/JPG uploads, unless the user explicitly approves raster fallback. If SVG export cleanup is slow, say so and ask before substituting.
+- **Raster quality gate:** hero/product/mockup images must use a 2× source when crispness matters. Verify the asset source/export is 2× or tell the user it is not confirmed.
+- **Dashed accent gate:** dashed lines, dividers, grids, accents, and underlines must use `repeating-linear-gradient`, not `border-style:dashed`, unless the user explicitly accepts browser-default dash rhythm.
+
 ### Speed defaults
 
 - Build in section-sized batches with `data_whtml_builder`; avoid element-by-element construction unless precision requires it.
@@ -298,7 +307,8 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 3. Ask whether to use Designer Bridge during the build or build headless first; explain the bridge is recommended for visual feedback but requires the Designer tab open and foregrounded.
 4. Ask how to handle Webflow variables, whether to use FlowKit naming / existing class patterns / semantic names, and whether to use `px`, `rem`, or `em` units.
 5. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
-6. Set up or map variables according to the selected design-system strategy, build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
+6. Confirm the build gates: Designer link/foreground tab if using bridge, SVG embeds for vector marks, 2× raster sources where needed, and gradient-based dashed accents.
+7. Set up or map variables according to the selected design-system strategy, build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
 
 ### Example 2: Recreate a Figma section in an existing Webflow page
 
@@ -307,8 +317,8 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 1. Extract the section's Figma tokens, assets, and reference code.
 2. Confirm the target Webflow site/page. Designer connection is only needed later for snapshot/visual QA or bridge-gated fallbacks.
 3. Confirm build mode plus variable, naming, and unit strategy before generating new Webflow classes/CSS; default to Designer Bridge, existing variables plus missing variables, FlowKit, and `px` if the user has no preference.
-4. Present a concise preview plan and require explicit confirmation before creating elements.
-5. Insert one section, constrain images with 2× sources where needed, verify structurally headless or visually with bridge snapshots if selected, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
+4. Present a concise preview plan that calls out the non-negotiable build gates, then require explicit confirmation before creating elements.
+5. Insert one section, constrain confirmed 2× images to display size, verify structurally headless or visually with bridge snapshots if selected, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
 
 ## Guidelines
 
@@ -325,8 +335,9 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 - [ ] All CSS longhand; correct breakpoints; flexbox-first.
 - [ ] Build mode followed: bridge-assisted by default with Designer tab open and foregrounded, or headless-first if the user chose it.
 - [ ] Webflow variables handled according to the selected strategy; repeated colors/type/spacing/radii are mapped or created unless hard-coding was explicitly selected.
-- [ ] Images attached by asset ID (not orphan `<img src>`); 2× where crispness matters.
-- [ ] Vector marks are clean inline-SVG embeds (backgrounds stripped).
+- [ ] Images attached by asset ID (not orphan `<img src>`); 2× source confirmed where crispness matters.
+- [ ] Vector marks are clean inline-SVG embeds (backgrounds stripped), or user explicitly approved raster fallback.
+- [ ] Dashed accents/dividers/grids use `repeating-linear-gradient`, not `border-style:dashed`, unless user explicitly approved browser-default dashes.
 - [ ] Fonts uploaded + referenced by exact family name; temp `<head>` link removed.
 - [ ] Runtime-toggled classes have guaranteed CSS (not stripped).
 - [ ] Responsive overrides at medium/small/tiny.

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -34,7 +34,7 @@ Webflow MCP has **two kinds of tools with different requirements**:
 ### 1. Workflow order
 
 1. **Gather** — Figma structure, tokens, per-section code/colors/assets; Webflow site, pages, existing styles.
-2. **Choose naming strategy** — ask how new Webflow styles should be named before creating any classes (see §3).
+2. **Choose style preferences** — ask how new Webflow styles should be named and which CSS units to use before creating any classes (see §3).
 3. **Set up foundations** — page wrapper w/ base typography; design tokens; fonts.
 4. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify after each.
 5. **Attach assets** (images by ID; inline SVGs via embeds).
@@ -52,9 +52,11 @@ Confirm ambiguous design intent up front (e.g., a button whose label is a repeat
   - **Gotcha:** the SVG export wraps the node in its ancestor chain and **bakes in background fills** clipped to the node box (page background rect, card background, a node "backing" rect). Strip the full-bleed background `<rect>`/`<path>` elements that aren't part of the target → clean transparent vector. (Remaining `fill="white"` inside `<defs><clipPath>` are just clip masks — leave them.)
 - **Raster (photos, complex product mockups): can't get 2× from `get_screenshot`.** Use the design-context layer export URLs (often already 2×) or composite the 2× image locally, then upload (see §5, §6).
 
-### 3. Naming new Webflow styles
+### 3. Style preferences
 
-Before creating new classes, ask:
+Before creating new classes or CSS, ask about naming and units.
+
+**Naming prompt:**
 
 > Do you want to use FlowKit naming conventions for new styles?
 
@@ -65,6 +67,18 @@ Offer these choices, with FlowKit selected as the recommended default:
 3. **Use clear semantic names for this build** — create layout/structure-based kebab-case names that are easy to maintain, without forcing FlowKit if the site does not use it.
 
 If the user does not choose, default to **FlowKit naming**. Never mix naming strategies casually within the same build; if an established site system conflicts with FlowKit, call out the tradeoff and ask before proceeding.
+
+**Unit prompt:**
+
+> Do you want this build to use px, rem, or em units?
+
+Offer these choices, with px selected as the default:
+
+1. **px (default)** — match Figma/Webflow values directly and avoid conversion drift.
+2. **rem** — use scalable root-relative units for typography and spacing where practical.
+3. **em** — use component-relative units where the design intentionally scales with local font size.
+
+If the user does not choose, default to **px**. Keep units consistent within a build; only mix units when there is a clear reason, such as `%` for fluid widths or `em` for icon/text relationships.
 
 ### 4. Webflow CSS rules (these bite)
 
@@ -80,6 +94,7 @@ If the user does not choose, default to **FlowKit naming**. Never mix naming str
 - **Forbidden / dropped:** `calc()`, `clamp()`, `min()/max()`, `@keyframes`, `@font-face`, multi-layer `box-shadow`, logical props, vendor prefixes. For animation use IX2 or a custom-code embed.
 - Put inheritable typography (font-family, color, base size/line-height) once on `.page-wrapper`; single font names, no fallback stacks.
 - Naming: follow the selected naming strategy. If using FlowKit, reference `webflow-mcp:flowkit-naming`; otherwise use layout/structure-based, kebab-case names and never page-prefixed names.
+- Units: follow the selected unit preference. Default to `px`; convert to `rem`/`em` only when the user chooses that strategy.
 
 ### 5. Building elements
 
@@ -90,11 +105,14 @@ If the user does not choose, default to **FlowKit naming**. Never mix naming str
 
 ### 6. Images & assets
 
-Two upload paths:
+Use the headless Data API asset path first. Do **not** rely on `asset_tool upload_image_by_url` as the primary path; it is Designer Bridge-gated and may be removed.
 
-- **Public URL → `asset_tool upload_image_by_url`.** Works for a Figma asset URL or any reachable CDN URL; **fully processes the asset (variants)** so it renders. This is the easy path.
-- **Local file → 3 steps:** `data_assets_tool create_asset` (with `file_hash` = MD5 of the bytes) → `curl` POST the bytes to the returned **presigned S3 form** → **then re-ingest via `upload_image_by_url` on the resulting CDN URL.** Skipping the re-ingest leaves the asset at `size:0` / no variants, and **the Designer won't render it.**
+- **Download Figma asset bytes locally first.** Use the Figma design-context/export URL promptly, write the file to `/tmp/`, and compute the MD5 hash of the actual bytes.
+- **Create the asset via `data_assets_tool create_asset`.** Pass `site_id`, `file_name`, and `file_hash`, then POST the local file bytes to the returned presigned S3 form.
   - The presigned **policy is base64 — validate it is pure ASCII** before POSTing (`grep '[^A-Za-z0-9+/=]'`); transcription homoglyphs cause a 403.
+  - Append the file field last in the multipart POST.
+- **Verify processing before placing the image.** Fetch/check the created asset after upload. If it remains `size:0` or has no variants, tell the user the upload succeeded but Webflow has not processed a renderable asset yet.
+- **Bridge-gated fallback:** if processed variants are required and `create_asset` does not process them, ask the user to open and foreground Webflow Designer before using any bridge-gated asset processing fallback. Do not assume `upload_image_by_url` will remain available.
 - **`whtml <img src="...">` does NOT link to the asset library by URL** ("inserted without a managed asset"). After inserting, `query_elements` for the `Image` and `set_image_asset` by asset ID.
 - **hiDPI/retina:** Webflow's HiDPI checkbox is Designer-UI-only. Equivalent via API: ship a **2× source and let CSS constrain it to its display width** → crisp automatically.
 - Delete orphaned `size:0` assets to keep the library clean.
@@ -192,15 +210,16 @@ Keep all **desktop visual styling** (colors, padding, link/burger-bar look) as n
 ### 14. Reference: local-file upload (presigned S3)
 
 ```bash
-# 1) create_asset returns uploadUrl + uploadDetails (presigned form) + hostedUrl
-# 2) POST the bytes (field order: form fields first, file LAST):
+# 1) Download/export the image locally and compute MD5 of the bytes.
+# 2) create_asset returns uploadUrl + uploadDetails (presigned form) + hostedUrl
+# 3) POST the bytes (field order: form fields first, file LAST):
 curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
   -F "key=$KEY" -F "acl=public-read" -F "Content-Type=image/png" \
   -F "cache-control=max-age=31536000" -F "success_action_status=201" \
   -F "X-Amz-Algorithm=..." -F "X-Amz-Credential=..." -F "X-Amz-Date=..." \
   -F "X-Amz-Signature=$SIG" -F "policy=$POLICY" -F "bucket=..." \
   -F "file=@/path/to/image.png"
-# 3) then upload_image_by_url on the returned hostedUrl  → processed asset that renders
+# 4) Verify the asset has nonzero size / variants before using its asset ID.
 ```
 
 > Validate `$POLICY` is pure base64 ASCII before sending: `printf '%s' "$POLICY" | grep -q '[^A-Za-z0-9+/=]' && echo "ABORT: non-ASCII in policy"`.
@@ -213,7 +232,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 1. Use Figma MCP to gather metadata, design context, variables, screenshots, and export URLs for the requested frame.
 2. Use Webflow MCP to call `webflow_guide_tool`, confirm the user/site/page, and inspect existing styles.
-3. Ask whether to use FlowKit naming, the existing Webflow design system, or clear semantic names for this build.
+3. Ask whether to use FlowKit naming, the existing Webflow design system, or clear semantic names; then ask whether to use `px`, `rem`, or `em` units.
 4. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
 5. Build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
 
@@ -223,7 +242,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 1. Extract the section's Figma tokens, assets, and reference code.
 2. Confirm the target Webflow site/page and Designer connection.
-3. Confirm the naming strategy before generating new Webflow classes; default to FlowKit if the user has no preference.
+3. Confirm naming and unit strategy before generating new Webflow classes/CSS; default to FlowKit and `px` if the user has no preference.
 4. Present a concise preview plan and require explicit confirmation before creating elements.
 5. Insert one section, constrain images with 2× sources where needed, verify with Designer snapshots, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
 
@@ -231,7 +250,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 - Always use Figma MCP for design extraction and Webflow MCP for Webflow operations; never use direct Webflow API calls.
 - Call `webflow_guide_tool` before other Webflow tools in the workflow.
-- Ask for a style naming strategy before creating classes. Default to FlowKit and reference `webflow-mcp:flowkit-naming` when that option is selected.
+- Ask for style naming and CSS unit strategy before creating classes. Default to FlowKit naming and `px`; reference `webflow-mcp:flowkit-naming` when FlowKit is selected.
 - Treat mutating Webflow operations as confirmation-gated. Require explicit user approval before creating, updating, publishing, or deleting.
 - Prefer `data_whtml_builder` for section construction, then use element tools for precise asset binding, embeds, and refinements.
 - Keep CSS Webflow-compatible: longhand properties, class selectors, desktop-first breakpoints, flexbox-first layout, and custom code for unsupported behavior.

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -13,15 +13,27 @@ description: >-
 # Figma → Webflow
 
 Translate a Figma design into a live Webflow project: real elements, styles,
-assets, fonts, and (optionally) custom code + interactions. This skill is the
-hard-won playbook — follow the order, and heed the gotchas (each is something
-that silently fails or wastes a publish cycle if you don't know it).
+assets, fonts, and (optionally) custom code + interactions.
 
 ## Instructions
 
-### 0. The single most important thing: two tool surfaces
+Follow this order exactly. When a step says to read a reference file, read it
+before doing that work; those files contain the failure modes for that step.
 
-Webflow MCP has **two kinds of tools with different requirements**:
+## Non-Negotiable Gates
+
+Treat these as build gates, not suggestions. If you cannot satisfy one, stop
+and explain the tradeoff instead of silently substituting.
+
+- **Bridge gate:** Designer Bridge is the default build mode. If selected, provide or request the Designer launch link and wait for the user to open the project with the Designer tab foregrounded before bridge-dependent steps. If the bridge disconnects, keep structural work headless and reconnect before snapshots/canvas inspection.
+- **Native style gate:** apply styles with `data_style_tool`, never with the `data_whtml_builder` `css` param or raw `var()` strings. Otherwise styles land in Custom properties instead of native controls. Bind Webflow variables with `variable_as_value`.
+- **Variables gate:** decide the Webflow variable/design-system strategy before creating styles. Do not hard-code repeated colors/type/spacing/radii unless the user explicitly chooses hard-coded output.
+- **Vector gate:** logos, icons, and marks must be inline SVG embeds, not PNG/JPG uploads, unless the user explicitly approves raster fallback.
+- **Raster quality gate:** hero/product/mockup images must use a confirmed 2x source where crispness matters.
+- **Dashed accent gate:** dashed lines, dividers, grids, accents, and underlines must use `repeating-linear-gradient`, not `border-style:dashed`, unless the user explicitly accepts browser-default dash rhythm.
+- **Publish gate:** do not publish by default. Offer `.webflow.io` publish only after build/review, and only proceed on explicit user confirmation.
+
+## Tool Surfaces
 
 | Surface | Examples | Needs Designer open? |
 |---|---|---|
@@ -33,47 +45,22 @@ Webflow MCP has **two kinds of tools with different requirements**:
 - If Designer is disconnected, continue structural work headlessly with `query_styles`, `get_all_elements`, and `query_elements`; reconnect the bridge for snapshots, canvas inspection, and any still-required bridge-gated image processing fallback.
 - If a bridge tool returns `status:false` or "Unable to connect to Webflow Designer," share the launch link and ask the user to open the Designer **and keep that browser tab in the foreground** — it idles/disconnects when backgrounded. Retry before assuming anything broke.
 
-### 1. Workflow order
+## Workflow
 
-1. **Gather** — Figma structure, tokens, per-section code/colors/assets; Webflow site, pages, existing styles.
-2. **Choose build mode and style preferences** — ask whether to build headless or bridge-assisted, then ask how Webflow variables, new styles, and CSS units should be handled before creating any classes/CSS (see §3).
-3. **Set up foundations** — Webflow variables/design tokens, page wrapper w/ base typography, and fonts.
-4. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify structurally after each, and visually if the user chose bridge-assisted mode.
-5. **Attach assets** (images by ID; inline SVGs via embeds).
-6. **Responsive pass** (desktop-first overrides).
-7. **Custom code / interactions** last (mobile menu, animated backgrounds, blur).
-8. **Offer review/publish next steps** — default to **no publish**. Only publish to the `.webflow.io` subdomain if the user explicitly asks or confirms after reviewing the build.
+### 1. Gather And Decide
 
-### Non-negotiable build gates
+1. Use Figma MCP:
+   - `get_metadata` for structure.
+   - `get_design_context` for major frames/sections.
+   - `get_variable_defs` for colors, type, spacing, radii.
+   - Read page/canvas background; do not assume white.
+2. Use Webflow MCP:
+   - `webflow_guide_tool` first.
+   - Confirm target site/page and inspect existing variables/styles.
+3. Ask the required setup prompts below.
+4. Confirm ambiguous design intent before building. If Figma component instances contain repeated placeholder labels, ask for intended copy instead of copying placeholders.
 
-Treat these as gates, not suggestions. Before building, explicitly confirm the planned choice for each item; if you cannot satisfy one, stop and explain the tradeoff instead of silently substituting.
-
-- **Bridge gate:** if the user chooses Designer Bridge (the default), provide/request the Designer launch link and wait for the user to open the project with the Designer tab foregrounded before running bridge-dependent steps. Do not skip this setup and start building as if headless were selected.
-- **Vector gate:** logos, icons, and marks must be inline SVG embeds, not PNG/JPG uploads, unless the user explicitly approves raster fallback. If SVG export cleanup is slow, say so and ask before substituting.
-- **Raster quality gate:** hero/product/mockup images must use a 2× source when crispness matters. Verify the asset source/export is 2× or tell the user it is not confirmed.
-- **Dashed accent gate:** dashed lines, dividers, grids, accents, and underlines must use `repeating-linear-gradient`, not `border-style:dashed`, unless the user explicitly accepts browser-default dash rhythm.
-
-### Speed defaults
-
-- Build in section-sized batches with `data_whtml_builder`; avoid element-by-element construction unless precision requires it.
-- Create variables/classes for common primitives once (containers, typography, spacing, buttons, image-fill, cards, nav) and reuse them aggressively.
-- Snapshot groups/wrappers, not every element. Prefer structural verification with `query_elements` / `query_styles` between visual checks.
-- Export complex layered visuals as 2× composed images instead of rebuilding every layer in Webflow.
-- Gather Figma metadata, variables, and major-section design context up front; avoid repeated per-node Figma calls for small children.
-- If using Designer Bridge, keep the tab foregrounded and batch several headless `data_*` operations between bridge snapshots.
-
-Confirm ambiguous design intent up front (e.g., a button whose label is a repeated component placeholder) rather than guessing. **If the build includes a navbar, ask which breakpoint the mobile menu should collapse at before building it (see §10).**
-
-### 2. Extracting from Figma
-
-- `get_metadata` → node/structure map. `get_design_context` per node → reference code + exact colors + asset download URLs + a screenshot. `get_variable_defs` → design tokens (colors, type scale, spacing, radii). Pull tokens early and treat them as law.
-- Read the page/canvas background color from Figma; do not assume white. Set the real page background on `.page-wrapper`, or white cards/sections can disappear against the wrong background.
-- **Asset URLs from design-context live ~7 days; `get_screenshot` URLs are short-lived** — upload promptly.
-- **Vector assets (logos, icons, marks): use `download_assets` with `defaultFormat: "svg"`** — NOT `get_screenshot`. Screenshot only rasterizes and **never upscales past the node's native size** (so it can't give you 2×, and it bakes in surrounding background).
-  - **Gotcha:** the SVG export wraps the node in its ancestor chain and **bakes in background fills** clipped to the node box (page background rect, card background, a node "backing" rect). Strip the full-bleed background `<rect>`/`<path>` elements that aren't part of the target → clean transparent vector. (Remaining `fill="white"` inside `<defs><clipPath>` are just clip masks — leave them.)
-- **Raster (photos, complex product mockups): can't get 2× from `get_screenshot`.** Use the design-context layer export URLs (often already 2×) or `download_assets` at 2× for a composed parent node; treat layered product mockups as one image instead of reconstructing every layer (see §5, §6).
-
-### 3. Build mode and style preferences
+### Required Prompts
 
 Before creating Webflow variables, classes, or CSS, ask about build mode, design-system strategy, naming, and units.
 
@@ -125,178 +112,45 @@ Offer these choices, with px selected as the default:
 
 If the user does not choose, default to **px**. Keep units consistent within a build; only mix units when there is a clear reason, such as `%` for fluid widths or `em` for icon/text relationships.
 
-### 4. Webflow CSS rules (these bite)
+### 2. Build Foundations And Sections
 
-- **Apply styles via `data_style_tool`, never via the `data_whtml_builder` `css` param or raw `var()` strings.** CSS passed as a raw blob through the WHTML `css` param lands in the Designer's **"Custom properties"** bucket (the arbitrary-custom-CSS panel) instead of mapping onto native Style-panel controls — the build looks non-native and is hard to edit. Use `create_style` / `update_style` to set properties (including responsive overrides), and bind variables natively with `variable_as_value: "<variable-id>"` (the id from `data_variable_tool`) — a raw `var(--collection---token)` string never renders the native variable pill. Only genuinely non-native CSS (`backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient` backgrounds, etc.) should remain in Custom properties; that's expected even in a hand-built site.
-- **Longhand only.** Expand `padding`, `margin`, `border`, `border-radius` (4 corners), `font`, `background`, `transition`, `flex`.
-- **Class selectors only.** No tag/ID/descendant/attribute selectors. `:hover` is the only safe pseudo-class; no `::before`/`::after` (use real elements).
-- **Gaps:** emit `grid-row-gap` / `grid-column-gap` even on flex (Webflow's stored keys) — not `row-gap`/`column-gap`.
-- **Desktop-first breakpoints (Webflow).** Override downward only; WHTML media queries need the `screen and` prefix (e.g., `@media screen and (max-width: 767px)`).
-  - **Desktop (base)** — applies to all devices unless overridden at another breakpoint.
-  - **Tablet** — screens **991px** and below.
-  - **Mobile landscape** — screens **767px** and below.
-  - **Mobile portrait** — screens **479px** and below.
-- **Flexbox-first**; grid only for true 2D.
-- **Forbidden / dropped:** `calc()`, `clamp()`, `min()/max()`, `@keyframes`, `@font-face`, multi-layer `box-shadow`, logical props, vendor prefixes. For animation use IX2 or a custom-code embed.
-- Put inheritable typography (font-family, color, base size/line-height) once on `.page-wrapper`; single font names, no fallback stacks.
-- Variables: follow the selected design-system strategy before building sections. Prefer Webflow variables for repeated colors, typography, spacing, and radii unless the user explicitly chooses hard-coded styles.
-- Naming: follow the selected naming strategy. If using FlowKit, reference `webflow-mcp:flowkit-naming`; otherwise use layout/structure-based, kebab-case names and never page-prefixed names.
-- Units: follow the selected unit preference. Default to `px`; convert to `rem`/`em` only when the user chooses that strategy.
+Before creating variables/classes/styles, read [CSS rules](references/css-rules.md).
 
-### 5. Building elements
+1. Create or map Webflow variables according to the selected strategy.
+2. Create reusable primitives first: page wrapper, containers, typography, spacing, buttons, image-fill, cards, nav.
+3. Use `data_whtml_builder` for DOM/structure only: one root section per action, semantic tags, nesting, text, and class names.
+4. Create styles with `data_style_tool create_style` / `update_style`. Repeat: do **not** use the WHTML `css` param for styling.
+5. Capture returned element ids. Re-find later with `query_elements`, then filter by exact class/type before acting.
+6. Build in section-sized batches. Prefer structural verification with `query_elements` / `query_styles` between visual checks.
 
-- **`data_whtml_builder` is the workhorse for DOM/structure** — pass HTML to build markup, nesting, and semantic tags; referencing class names in the HTML is fine. Build one section per call, set `return_element_info:true`, and use the returned id as the parent for the next insert. Class selectors in the WHTML `css` param do become real Webflow styles, but they get stored as non-native **Custom properties** rather than native style-panel controls — so create/update styling via `data_style_tool` instead (with `variable_as_value` for variable bindings) so it maps to native Webflow controls (see §4).
-- **Element identity & page context:** an element id is `{component, element}` where **`component` IS the page id**. `data_element_tool` actions must run with the **matching top-level `pageId`** — a mismatch returns "Element not found." This is exactly how you target a *duplicated* page's elements (pass that page's id).
-- `data_element_builder` (typed elements, supports `set_style`/`set_image_asset`/children at creation) is the fallback when you need precise control; component instances need `component_builder`.
-- Keep nesting ≤4–5 levels.
+### 3. Attach Assets
 
-### 6. Images & assets
+Before handling images or vectors, read [Assets and SVG](references/assets-and-svg.md).
 
-Use the headless Data API asset path first. Do **not** rely on `asset_tool upload_image_by_url` as the primary path; it is Designer Bridge-gated and may be removed.
+1. Use `data_assets_tool create_asset` for raster assets. Download source bytes locally, compute MD5, POST to presigned S3, then verify nonzero size/variants before placement.
+2. For hero/product/mockup images, confirm 2x source before placement.
+3. Bind images by asset ID with `set_image_asset`; never rely on raw `<img src="...">`.
+4. Inline vector marks as `HtmlEmbed` SVGs and set embed code with `data_element_tool set_settings`.
+5. Upload fonts with `data_fonts_tool`; never add Google Fonts `<link>` tags to head.
 
-- **Download Figma asset bytes locally first.** Use the Figma design-context/export URL promptly, write the file to `/tmp/`, and compute the MD5 hash of the actual bytes.
-- **Create the asset via `data_assets_tool create_asset`.** Pass `site_id`, `file_name`, and `file_hash`, then POST the local file bytes to the returned presigned S3 form.
-  - The presigned **policy is base64 — validate it is pure ASCII** before POSTing (`grep '[^A-Za-z0-9+/=]'`); transcription homoglyphs cause a 403.
-  - Append the file field last in the multipart POST.
-- **Verify processing before placing the image.** Fetch/check the created asset after upload. If it remains `size:0` or has no variants, tell the user the upload succeeded but Webflow has not processed a renderable asset yet.
-- **Bridge-gated fallback:** if processed variants are required and `create_asset` does not process them, raise the issue rather than reverting silently. If a fallback is still available, ask the user to open and foreground Webflow Designer. Do not assume `upload_image_by_url` will remain available.
-- **`whtml <img src="...">` does NOT link to the asset library by URL** ("inserted without a managed asset"). After inserting, `query_elements` for the `Image` and `set_image_asset` by asset ID.
-- Bind images by asset ID with `set_image_asset`, or create the Image with `data_element_builder` and `set_image_asset` in the same step when possible. Apply an image-fill class (`width:100%; height:100%; object-fit:cover; display:block`) inside the image's container/placeholder.
-- **hiDPI/retina:** Webflow's HiDPI checkbox is Designer-UI-only. Equivalent via API: ship a **2× source and let CSS constrain it to its display width** → crisp automatically.
-- Delete orphaned `size:0` assets to keep the library clean.
+### 4. Navbar And Custom Behavior
 
-### 7. SVG, logos, icons → use embeds
+If the build includes a navbar, read [Navbar](references/navbar.md) before building it.
 
-- **An SVG uploaded as an asset and placed via `<img>` can render as a filled blob** when it has gradients/complex fills. **Inline the SVG inside an `HtmlEmbed`** for crisp, transparent, recolorable vectors.
-- **Setting embed code:** create the `HtmlEmbed` (code can't be set at creation), then `data_element_tool set_settings` with key `"code"` and the raw markup as `static_text`.
-- To avoid malformed tool-call JSON, single-quote SVG attributes, optimize before transcribing, collapse whitespace, round path coordinates to ~1 decimal, and do one SVG per call. Around 13 KB is usually reliable; 16–20 KB is risky.
-- Strip Figma SVG export noise: full-page/canvas backing rects, dashed component-boundary rects, off-target paths, and unused `id` attributes. Keep ids referenced by `url(#...)` gradients/clips and leave `fill="white"` inside `<defs><clipPath>` alone.
-- Crop the SVG `viewBox` to the artwork bounds and put `style="height:Npx; width:auto; display:block"` on the root `<svg>` when sizing by height. If the export is too messy, ask the user to paste Figma's cleaner "Copy as SVG" output.
-- Regex gotcha when parsing SVG: `id="X"` contains `d="X"` as a substring. Match `\sd="` with a leading boundary, not bare `d="`.
-- Dark-background variant: duplicate the SVG and swap wordmark `fill` hex to white (leave `fill="url(#…)"` gradient fills alone).
-- **`set_text("")` on a Link wipes its child embeds.** Never clear a link's text after inserting an icon embed (or re-add the embed after).
-- For multiple logos of different proportions, **crop each SVG `viewBox` to its content bounds** so you can size them uniformly in a flex row.
+- Ask which breakpoint should collapse to hamburger.
+- Webflow native Navbar cannot be created via API/WHTML. Build a semantic custom nav or ask the user to add the native element in Designer.
+- Put component behavior `<style>`/`<script>` in an HtmlEmbed inside the component root. Use site/page head code only for truly global behavior.
 
-### 8. Fonts (`data_fonts_tool`)
+### 5. Responsive And QA
 
-- Upload fonts with `data_fonts_tool`: `create_font` (`file_hash` = MD5 of the woff2) → presigned upload → POST the bytes. Source woff2 from the Google Fonts `css2` endpoint (latin subset) with a desktop User-Agent when needed.
-- Never add Google Fonts `<link>` tags to page/site `<head>` after uploading fonts; they create duplicate `@font-face` declarations. Reference fonts by **exact family name** in CSS.
-- First snapshots can show fallback fonts during the cold-cache `font-display: swap` window. Warm the cache with a throwaway/full-page snapshot and re-snapshot before "fixing" fonts. Do not add head links to solve snapshot-only fallback fonts.
-- Variable-font woff2 files can serve multiple weights; registering each weight against the same source file is acceptable.
+Before responsive/final verification, read [Verification](references/verification.md).
 
-### 9. Custom code & interactions
-
-- **Prefer component-scoped HtmlEmbeds for component behavior** (e.g., navbar mobile-toggle CSS/JS) so the behavior travels if the element becomes a Webflow component. Create the embed inside the component root, then set code via `data_element_tool set_settings`.
-- Use `data_scripts_tool set_site_freeform_code` (head/footer) only for genuinely global `<style>`/`<script>`. The *registered-script* apply endpoints (`add_site_script`/`add_page_script`) may 404 depending on the site; freeform code is reliable.
-- **Unused combo classes get stripped from published CSS.** A class you only toggle at runtime via JS (e.g., `.menu.is-open`) has **no matching rule** unless you (a) apply the combo to an element in the Designer, or (b) **guarantee the rule in a head `<style>`**. This silently makes JS toggles do nothing.
-- **HTML embed + `<style>`/`<script>` is the escape hatch** for anything Webflow's panel can't express: parent-state→child selectors, custom mobile-menu toggle, or any CSS/JS Webflow strips or can't model.
-- **Native components (Navbar, etc.) cannot be created via API/whtml** — whtml just produces generic blocks with `w-*` class names (no real component JS/CSS). Either build a custom equivalent (+ a small delegated-click script) or have the user add the native element in the Designer.
-
-### 10. Navbar (reusable recipe)
-
-Webflow's native Navbar component can't be created via the API/whtml (whtml only yields generic blocks), yet most sites need one. Build a **semantic `<nav>` from Webflow custom elements** + a **CSS-only mobile toggle in a code embed** — no JS, no native component.
-
-**Always ask first:** *which breakpoint should the menu collapse to a hamburger?* Then recommend based on the design, and use their answer as `{BP}`:
-- **≤3–4 short links, no/short CTA** → Mobile landscape (**767**) or Mobile portrait (**479**) — they stay readable longer.
-- **5+ links, long labels, or a prominent CTA** → Tablet (**991**) — collapse earlier so the bar never crowds.
-- State your recommendation with the reason, then defer to their choice.
-
-**Structure** — build with custom tags (`set_tag` / `BY_CUSTOM_TAG`) so it's semantic and Designer-editable:
-
-```html
-<nav class="nav">                         ← custom element, tag = nav; position: relative (or sticky/fixed)
-  <div class="nav-inner">                 ← flex row, space-between, max-width container
-    <a class="nav-brand" href="/">…logo…</a>
-    <input type="checkbox" id="nav-toggle" class="nav-cb">   ← custom tag "input", attr type=checkbox
-    <label for="nav-toggle" class="nav-burger">              ← custom tag "label", attr for=nav-toggle
-      <span class="nav-burger-bar"></span> ×3
-    </label>
-    <div class="nav-menu">                 ← links + CTA (real, editable Webflow links)
-      <a class="nav-link" href="#">…</a> …
-      <a class="btn" href="#">CTA</a>
-    </div>
-  </div>
-</nav>
-```
-
-**Critical:** the checkbox must be a **previous sibling** of `.nav-menu` (order: brand → checkbox → burger → menu) so `:checked ~ .nav-menu` resolves. Make `.nav` (or `.nav-inner`) `position: relative` so the dropdown anchors to the bar. Use custom-tag `input`/`label` (not the Form Checkbox element) to avoid Webflow's `.w-checkbox` wrapper, which would break the sibling chain.
-
-**Behavior — one code embed, CSS only** (replace `{BP}` with the chosen breakpoint). This CSS uses `:checked ~` + a media query that Webflow's style panel can't express — which is exactly why it lives in an embed:
-
-```html
-<style>
-  .nav-cb{ position:absolute; width:1px; height:1px; opacity:0; pointer-events:none; }  /* a11y-hidden toggle */
-  .nav-burger{ display:none; }                       /* hidden on desktop */
-  @media screen and (max-width:{BP}px){
-    .nav-burger{ display:flex; flex-direction:column; row-gap:5px; cursor:pointer; }
-    .nav-menu{
-      display:none; position:absolute; top:100%; left:0; right:0;
-      flex-direction:column; align-items:flex-start; row-gap:4px;
-      padding:16px 24px; background:#fff; box-shadow:0 10px 24px rgba(0,0,0,.10);
-    }
-    .nav-cb:checked ~ .nav-menu{ display:flex; }      /* pure-CSS open/close */
-  }
-</style>
-```
-
-Keep all **desktop visual styling** (colors, padding, link/burger-bar look) as normal Webflow classes; the embed holds only the responsive + toggle **behavior**.
-
-**Tradeoffs:** the pure-CSS toggle is zero-JS and publish-safe, but doesn't set `aria-expanded` or close on outside-click. If the client needs those, swap the embed for a small JS toggle (delegated click + class toggle) — but a JS-toggled class needs its open-state rule **guaranteed in custom code** (an unused combo class is stripped from published CSS — see §9). Optionally animate the bars to an "X" via `.nav-cb:checked ~ .nav-burger` rules inside the same embed.
-
-### 11. Isolating experiments / "branching"
-
-- **Page-branching API may be unavailable** (`create_branch`/`list_branches` → 404). Substitute: **`create_page` with `duplicateOf`** to clone the page as an experiment "branch" (gets its own page id; target its elements with that `pageId`). Revert main by deleting the experimental elements.
-- For reversible enhancements, **layer the new thing over a static fallback** (e.g., an animated canvas over the static gradient image) rather than replacing it.
-
-### 12. Verification & its hard limits
-
-- `element_snapshot_tool`: Designer-foreground only; **desktop viewport only (no responsive/mobile simulation)**; **does not execute embeds / WebGL / `backdrop-filter`** (those render only on the published/preview site).
-- Isolated-section snapshots do not include sibling overlays (e.g., page-level grids/backgrounds). Verify overlays/layering with a full-page composite snapshot of the top-level wrapper.
-- Transparent regions render as **black** in isolated snapshots; on the page they show the page background. `position:fixed` elements can render unreliably in composites; verify clearance on preview/live.
-- First snapshot of a session can show fallback fonts; warm the cache and re-snapshot before changing font implementation.
-- You **cannot fetch `*.webflow.io`** (robots-blocked) or run JS on it. So:
-  - If the user chooses to publish to the subdomain, ask them to confirm anything you can't see in the Designer — embed behavior, custom-code, mobile/responsive widths. Never claim an embed is verified from your side.
-
-### 13. Layout patterns worth reusing
-
-- **Background grid lines:** `repeating-linear-gradient` for dashes (control dash/gap precisely — a CSS dashed *border* can't). Give each line element a **real width (≥1px)** so Webflow doesn't flag it as an empty/clickable zero-width element. Place at `z-index:-1` inside a stacking-context wrapper so it sits behind content but above the page background.
-- Use `repeating-linear-gradient`, not `border-style:dashed`, for dashed accents/dividers/underlines so dash length, gap, opacity, and direction match the design rhythm.
-- Decorative overlays must sit behind content. Make `.page-wrapper` a stacking context (`position:relative; z-index:0`) and place overlays at `z-index:-1`; opaque cards then hide the overlay while gutters show it.
-- Never use a fixed overlay width wider than the viewport. Prefer `left:0; right:0; width:auto; max-width:<design-width>; margin-left:auto; margin-right:auto`.
-- Replicate interior grid lines too, not just outer edges; check Figma for distributed columns (e.g., 25/50/75%).
-- **Perceived weight ≠ literal alpha:** lines *behind* content read lighter than identical lines *in front* (occlusion). Match the perceived weight when pairing them.
-- **Section dividers:** use a thin absolutely-positioned gradient-line element to match a dashed grid's rhythm, not a dashed `border`.
-- **Fixed vs sticky nav:** `fixed` lets the first section sit *under* the bar (useful when the nav is translucent/overlays content); then add top-padding to that section to clear the bar. `sticky` reserves space (content starts below the bar).
-- **Replacing an `<img>` with an embed loses the img's classes/margins** — reapply spacing on the embed.
-
-### 14. Build mechanics & gotchas
-
-- `data_whtml_builder` requires a single root element per action. To insert multiple sibling sections, use multiple actions.
-- Styles applied via `data_whtml_builder`'s `css` param (or as raw `var()` strings) are stored as Designer "Custom properties", not native style-panel controls — always set styles through `data_style_tool` and bind variables with `variable_as_value`.
-- `set_style` replaces all classes on an element. If a class does not exist yet, create it with `data_style_tool create_style`; do not define it through the WHTML CSS param.
-- `query_elements` style filters are case-insensitive substring matches; filter returned elements by exact class/type before acting.
-- Responsive work is headless: use `data_style_tool update_style` with breakpoint IDs (`main` base, then `medium`, `small`, `tiny`). Desktop-first: set base, override downward.
-- Capture returned element ids from every insert. Re-find later by exact style/type when possible. Element ids are `{component, element}`, where `component` is the page id.
-- Combo classes (`["base","modifier"]`) can be ambiguous. When in doubt, prefer one standalone class with full styling.
-- Figma component instances often carry repeated placeholder labels (e.g., identical button text). Confirm intended labels with the user instead of copying placeholders verbatim.
-- Suppress Designer-only `.wf-empty` affordances on decorative empty elements by giving normal DivBlocks a dimension-giving style in the active breakpoint (explicit zero padding works). For custom-tag empty elements, add a child or use a normal DivBlock instead.
-
-### 15. Reference: local-file upload (presigned S3)
-
-```bash
-# 1) Download/export the image locally and compute MD5 of the bytes.
-# 2) create_asset returns uploadUrl + uploadDetails (presigned form) + hostedUrl
-# 3) POST the bytes (field order: form fields first, file LAST):
-curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
-  -F "key=$KEY" -F "acl=public-read" -F "Content-Type=image/png" \
-  -F "cache-control=max-age=31536000" -F "success_action_status=201" \
-  -F "X-Amz-Algorithm=..." -F "X-Amz-Credential=..." -F "X-Amz-Date=..." \
-  -F "X-Amz-Signature=$SIG" -F "policy=$POLICY" -F "bucket=..." \
-  -F "file=@/path/to/image.png"
-# 4) Verify the asset has nonzero size / variants before using its asset ID.
-```
-
-> Validate `$POLICY` is pure base64 ASCII before sending: `printf '%s' "$POLICY" | grep -q '[^A-Za-z0-9+/=]' && echo "ABORT: non-ASCII in policy"`.
+1. Use `data_style_tool update_style` with breakpoint ids (`main`, `medium`, `small`, `tiny`). Desktop-first: set base, override downward.
+2. If Designer Bridge is selected, snapshot groups/wrappers rather than every element. Keep the Designer tab foregrounded.
+3. Verify overlays/layering with a full-page composite, not isolated-section snapshots.
+4. Do not trust first snapshots for fonts; warm cache and re-snapshot before changing font implementation.
+5. Do not claim embed behavior, custom code, blur, WebGL, animation, or mobile widths are verified from your side. Ask the user to confirm in preview/published site.
+6. Offer publish/review next steps. Default remains **no publish**.
 
 ## Examples
 
@@ -310,14 +164,14 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 4. Ask how to handle Webflow variables, whether to use FlowKit naming / existing class patterns / semantic names, and whether to use `px`, `rem`, or `em` units.
 5. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
 6. Confirm the build gates: Designer link/foreground tab if using bridge, SVG embeds for vector marks, 2× raster sources where needed, and gradient-based dashed accents.
-7. Set up or map variables according to the selected design-system strategy, build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
+7. Read the referenced files at their point of use, set up or map variables, build DOM with `data_whtml_builder`, style with `data_style_tool`, attach assets by Webflow asset ID, verify, then ask whether they want to publish to `.webflow.io`. Default to no.
 
 ### Example 2: Recreate a Figma section in an existing Webflow page
 
 **User:** "Recreate this pricing section from Figma on my homepage."
 
 1. Extract the section's Figma tokens, assets, and reference code.
-2. Confirm the target Webflow site/page. Designer connection is only needed later for snapshot/visual QA or bridge-gated fallbacks.
+2. Confirm the target Webflow site/page and ask whether to use the default Designer Bridge flow or build headless first.
 3. Confirm build mode plus variable, naming, and unit strategy before generating new Webflow classes/CSS; default to Designer Bridge, existing variables plus missing variables, FlowKit, and `px` if the user has no preference.
 4. Present a concise preview plan that calls out the non-negotiable build gates, then require explicit confirmation before creating elements.
 5. Insert one section, constrain confirmed 2× images to display size, verify structurally headless or visually with bridge snapshots if selected, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
@@ -328,12 +182,13 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 - Call `webflow_guide_tool` before other Webflow tools in the workflow.
 - Ask for build mode, Webflow variable, style naming, and CSS unit strategy before creating classes. Default to Designer Bridge, existing variables plus missing variables, FlowKit naming, and `px`; reference `webflow-mcp:flowkit-naming` when FlowKit is selected.
 - Treat mutating Webflow operations as confirmation-gated. Require explicit user approval before creating, updating, publishing, or deleting.
-- Prefer `data_whtml_builder` for section construction, then use element tools for precise asset binding, embeds, and refinements.
-- Keep CSS Webflow-compatible: longhand properties, class selectors, desktop-first breakpoints, flexbox-first layout, and custom code for unsupported behavior.
+- Prefer `data_whtml_builder` for DOM/section construction, then `data_style_tool` for all styling and element tools for precise asset binding, embeds, and refinements.
+- Keep CSS Webflow-compatible. Only non-native CSS belongs in Custom properties.
 - Do not publish by default. If the user wants a live review link, publish to the `.webflow.io` subdomain before any custom domains.
 
 ## Checklist before declaring done
 
+- [ ] Required reference files were read at their point of use.
 - [ ] All CSS longhand; correct breakpoints; flexbox-first.
 - [ ] Styles applied via `data_style_tool` (native controls), variables bound with `variable_as_value`, and only truly non-native CSS (`backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient`, etc.) left as custom properties.
 - [ ] Build mode followed: bridge-assisted by default with Designer tab open and foregrounded, or headless-first if the user chose it.

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -34,8 +34,8 @@ Webflow MCP has **two kinds of tools with different requirements**:
 ### 1. Workflow order
 
 1. **Gather** — Figma structure, tokens, per-section code/colors/assets; Webflow site, pages, existing styles.
-2. **Choose style preferences** — ask how new Webflow styles should be named and which CSS units to use before creating any classes (see §3).
-3. **Set up foundations** — page wrapper w/ base typography; design tokens; fonts.
+2. **Choose style preferences** — ask how Webflow variables, new styles, and CSS units should be handled before creating any classes/CSS (see §3).
+3. **Set up foundations** — Webflow variables/design tokens, page wrapper w/ base typography, and fonts.
 4. **Build section by section** via `data_whtml_builder` (capture each returned element id to nest the next piece). Verify after each.
 5. **Attach assets** (images by ID; inline SVGs via embeds).
 6. **Responsive pass** (desktop-first overrides).
@@ -54,7 +54,20 @@ Confirm ambiguous design intent up front (e.g., a button whose label is a repeat
 
 ### 3. Style preferences
 
-Before creating new classes or CSS, ask about naming and units.
+Before creating Webflow variables, classes, or CSS, ask about design-system strategy, naming, and units.
+
+**Design-system prompt:**
+
+> How should I handle Webflow variables for this build?
+
+Offer these choices, with "read existing variables and create missing ones" selected as the recommended default for existing sites:
+
+1. **Read existing variables and create missing ones (recommended)** — inspect current Webflow variables first, map Figma tokens to existing variables when possible, and create only the missing colors, typography, spacing, and radius variables needed for the design.
+2. **Create a new design system from scratch** — create a fresh variable set from the Figma design's colors, typography, spacing, and radii before building sections. Best for blank/new sites or isolated experiments.
+3. **Use existing variables only** — inspect and use only variables that already exist in Webflow. If a Figma token has no match, ask before hard-coding or changing the design.
+4. **Do not use Webflow variables** — hard-code values in the generated styles. Use only when the user explicitly chooses speed or one-off output over maintainability.
+
+If the user does not choose, default to **read existing variables and create missing ones**. For a brand-new/blank site, recommend **create a new design system from scratch** and explain why before proceeding.
 
 **Naming prompt:**
 
@@ -93,6 +106,7 @@ If the user does not choose, default to **px**. Keep units consistent within a b
 - **Flexbox-first**; grid only for true 2D.
 - **Forbidden / dropped:** `calc()`, `clamp()`, `min()/max()`, `@keyframes`, `@font-face`, multi-layer `box-shadow`, logical props, vendor prefixes. For animation use IX2 or a custom-code embed.
 - Put inheritable typography (font-family, color, base size/line-height) once on `.page-wrapper`; single font names, no fallback stacks.
+- Variables: follow the selected design-system strategy before building sections. Prefer Webflow variables for repeated colors, typography, spacing, and radii unless the user explicitly chooses hard-coded styles.
 - Naming: follow the selected naming strategy. If using FlowKit, reference `webflow-mcp:flowkit-naming`; otherwise use layout/structure-based, kebab-case names and never page-prefixed names.
 - Units: follow the selected unit preference. Default to `px`; convert to `rem`/`em` only when the user chooses that strategy.
 
@@ -232,9 +246,9 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 1. Use Figma MCP to gather metadata, design context, variables, screenshots, and export URLs for the requested frame.
 2. Use Webflow MCP to call `webflow_guide_tool`, confirm the user/site/page, and inspect existing styles.
-3. Ask whether to use FlowKit naming, the existing Webflow design system, or clear semantic names; then ask whether to use `px`, `rem`, or `em` units.
+3. Ask how to handle Webflow variables, whether to use FlowKit naming / existing class patterns / semantic names, and whether to use `px`, `rem`, or `em` units.
 4. Ask about ambiguous design intent and navbar collapse breakpoint if relevant.
-5. Build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
+5. Set up or map variables according to the selected design-system strategy, build foundations and sections via `data_whtml_builder`, attach assets by Webflow asset ID, verify each section, then ask whether they want to publish to the `.webflow.io` subdomain. Default to no.
 
 ### Example 2: Recreate a Figma section in an existing Webflow page
 
@@ -242,7 +256,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 1. Extract the section's Figma tokens, assets, and reference code.
 2. Confirm the target Webflow site/page and Designer connection.
-3. Confirm naming and unit strategy before generating new Webflow classes/CSS; default to FlowKit and `px` if the user has no preference.
+3. Confirm variable, naming, and unit strategy before generating new Webflow classes/CSS; default to existing variables plus missing variables, FlowKit, and `px` if the user has no preference.
 4. Present a concise preview plan and require explicit confirmation before creating elements.
 5. Insert one section, constrain images with 2× sources where needed, verify with Designer snapshots, and ask the user to confirm any embed or responsive behavior that cannot be self-verified.
 
@@ -250,7 +264,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 
 - Always use Figma MCP for design extraction and Webflow MCP for Webflow operations; never use direct Webflow API calls.
 - Call `webflow_guide_tool` before other Webflow tools in the workflow.
-- Ask for style naming and CSS unit strategy before creating classes. Default to FlowKit naming and `px`; reference `webflow-mcp:flowkit-naming` when FlowKit is selected.
+- Ask for Webflow variable, style naming, and CSS unit strategy before creating classes. Default to existing variables plus missing variables, FlowKit naming, and `px`; reference `webflow-mcp:flowkit-naming` when FlowKit is selected.
 - Treat mutating Webflow operations as confirmation-gated. Require explicit user approval before creating, updating, publishing, or deleting.
 - Prefer `data_whtml_builder` for section construction, then use element tools for precise asset binding, embeds, and refinements.
 - Keep CSS Webflow-compatible: longhand properties, class selectors, desktop-first breakpoints, flexbox-first layout, and custom code for unsupported behavior.
@@ -259,6 +273,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 ## Checklist before declaring done
 
 - [ ] All CSS longhand; correct breakpoints; flexbox-first.
+- [ ] Webflow variables handled according to the selected strategy; repeated colors/type/spacing/radii are mapped or created unless hard-coding was explicitly selected.
 - [ ] Images attached by asset ID (not orphan `<img src>`); 2× where crispness matters.
 - [ ] Vector marks are clean inline-SVG embeds (backgrounds stripped).
 - [ ] Fonts uploaded + referenced by exact family name; temp `<head>` link removed.

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -127,6 +127,7 @@ If the user does not choose, default to **px**. Keep units consistent within a b
 
 ### 4. Webflow CSS rules (these bite)
 
+- **Apply styles via `data_style_tool`, never via the `data_whtml_builder` `css` param or raw `var()` strings.** CSS passed as a raw blob through the WHTML `css` param lands in the Designer's **"Custom properties"** bucket (the arbitrary-custom-CSS panel) instead of mapping onto native Style-panel controls — the build looks non-native and is hard to edit. Use `create_style` / `update_style` to set properties (including responsive overrides), and bind variables natively with `variable_as_value: "<variable-id>"` (the id from `data_variable_tool`) — a raw `var(--collection---token)` string never renders the native variable pill. Only genuinely non-native CSS (`backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient` backgrounds, etc.) should remain in Custom properties; that's expected even in a hand-built site.
 - **Longhand only.** Expand `padding`, `margin`, `border`, `border-radius` (4 corners), `font`, `background`, `transition`, `flex`.
 - **Class selectors only.** No tag/ID/descendant/attribute selectors. `:hover` is the only safe pseudo-class; no `::before`/`::after` (use real elements).
 - **Gaps:** emit `grid-row-gap` / `grid-column-gap` even on flex (Webflow's stored keys) — not `row-gap`/`column-gap`.
@@ -144,7 +145,7 @@ If the user does not choose, default to **px**. Keep units consistent within a b
 
 ### 5. Building elements
 
-- **`data_whtml_builder` is the workhorse** — pass HTML + raw CSS; class selectors become real Webflow styles automatically. Build one section per call, set `return_element_info:true`, and use the returned id as the parent for the next insert.
+- **`data_whtml_builder` is the workhorse for DOM/structure** — pass HTML to build markup, nesting, and semantic tags; referencing class names in the HTML is fine. Build one section per call, set `return_element_info:true`, and use the returned id as the parent for the next insert. Class selectors in the WHTML `css` param do become real Webflow styles, but they get stored as non-native **Custom properties** rather than native style-panel controls — so create/update styling via `data_style_tool` instead (with `variable_as_value` for variable bindings) so it maps to native Webflow controls (see §4).
 - **Element identity & page context:** an element id is `{component, element}` where **`component` IS the page id**. `data_element_tool` actions must run with the **matching top-level `pageId`** — a mismatch returns "Element not found." This is exactly how you target a *duplicated* page's elements (pass that page's id).
 - `data_element_builder` (typed elements, supports `set_style`/`set_image_asset`/children at creation) is the fallback when you need precise control; component instances need `component_builder`.
 - Keep nesting ≤4–5 levels.
@@ -271,7 +272,8 @@ Keep all **desktop visual styling** (colors, padding, link/burger-bar look) as n
 ### 14. Build mechanics & gotchas
 
 - `data_whtml_builder` requires a single root element per action. To insert multiple sibling sections, use multiple actions.
-- `set_style` replaces all classes on an element. If a class does not exist yet, create it with `data_style_tool create_style` or define it in the WHTML CSS param so Webflow creates it.
+- Styles applied via `data_whtml_builder`'s `css` param (or as raw `var()` strings) are stored as Designer "Custom properties", not native style-panel controls — always set styles through `data_style_tool` and bind variables with `variable_as_value`.
+- `set_style` replaces all classes on an element. If a class does not exist yet, create it with `data_style_tool create_style`; do not define it through the WHTML CSS param.
 - `query_elements` style filters are case-insensitive substring matches; filter returned elements by exact class/type before acting.
 - Responsive work is headless: use `data_style_tool update_style` with breakpoint IDs (`main` base, then `medium`, `small`, `tiny`). Desktop-first: set base, override downward.
 - Capture returned element ids from every insert. Re-find later by exact style/type when possible. Element ids are `{component, element}`, where `component` is the page id.
@@ -333,6 +335,7 @@ curl -s -o /dev/null -w "%{http_code}" -X POST "$UPLOAD_URL" \
 ## Checklist before declaring done
 
 - [ ] All CSS longhand; correct breakpoints; flexbox-first.
+- [ ] Styles applied via `data_style_tool` (native controls), variables bound with `variable_as_value`, and only truly non-native CSS (`backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient`, etc.) left as custom properties.
 - [ ] Build mode followed: bridge-assisted by default with Designer tab open and foregrounded, or headless-first if the user chose it.
 - [ ] Webflow variables handled according to the selected strategy; repeated colors/type/spacing/radii are mapped or created unless hard-coding was explicitly selected.
 - [ ] Images attached by asset ID (not orphan `<img src>`); 2× source confirmed where crispness matters.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/assets-and-svg.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/assets-and-svg.md
@@ -33,21 +33,27 @@ printf '%s' "$POLICY" | grep -q '[^A-Za-z0-9+/=]' && echo "ABORT: non-ASCII in p
 
 - Logos, icons, and marks must be inline SVG inside `HtmlEmbed`, not uploaded SVG assets in `<img>`, unless the user explicitly approves fallback.
 - Gradient/complex SVGs placed as `<img>` can render as a filled blob; inline embed avoids that.
-- Create the `HtmlEmbed` first, then set code via `data_element_tool set_settings` with key `"code"` and the raw markup as `static_text`. Do not rely on setting embed code at element creation.
-- To avoid malformed tool-call JSON:
+- Prefer Figma right-click **Copy as SVG** for logos/marks/icons; it usually gives clean artwork with tight bounds. Use MCP `download_assets` / design-context SVG export only when clipboard output is unavailable, and expect scaffolding to strip.
+- Create the `HtmlEmbed` first, then set code via `data_element_tool set_settings` with key `"code"` as `static_text`.
+- Pass the SVG as the literal `static_text.value` of the `code` setting and let the tool layer encode it. Do not hand-build, pre-escape, or wrap the arguments in a raw/blob form. If you get "could not be parsed as JSON," the tool call is malformed; fix the call shape, do not shrink the SVG.
+- There is no ~13 KB per-SVG `set_settings` ceiling; 20 KB can pass as a string value. The real practical limit is Webflow Designer's HTML Embed UI, about 10,000 characters. Data API embeds over ~10k can render, but they are not safely hand-editable in Designer and may be truncated if opened/re-saved. If the embed must remain Designer-editable, reduce it below ~10k.
+- Optimize only as needed:
   - Single-quote SVG attributes.
   - Collapse whitespace between tags.
-  - Round path coordinates to about 1 decimal.
   - Hoist shared fill to the root `<svg>` where possible.
-  - Do one SVG per tool call. Around 13 KB is usually reliable; 16-20 KB is risky.
-- Clean Figma SVG exports:
-  - Strip full-page/canvas backing rects.
-  - Strip dashed component-boundary rects.
+  - Keep vectorized wordmark text as paths; never substitute live text for logo text unless the user explicitly wants editable text.
+  - Never round coordinates to integers; it destroys curves on small artwork. One decimal is the floor, and only round if needed to fit the ~10k Designer-editable limit.
+- Clean MCP/Figma SVG exports:
+  - Strip full-canvas backing `<rect>` elements by oversized dimensions, not just fill; some inherit the root fill and render as a giant dark box.
+  - Strip page-fill `<path>` elements, often `#F4F1FD` or `#F3F5F7`.
+  - Strip dashed component-boundary `<rect stroke="#9747FF" stroke-dasharray=...>`.
+  - Strip nested wrapper `<g id>` elements when not needed.
+  - Strip `<defs><clipPath>` scaffolding only when no kept artwork references it.
   - Remove off-target paths and unused `id` attributes.
   - Keep ids referenced by `url(#...)` gradients/clips.
-  - Leave `fill="white"` inside `<defs><clipPath>` alone; those are masks.
-- Crop the `viewBox` to artwork bounds. For height-based sizing, put `style="height:Npx; width:auto; display:block"` on the root `<svg>`.
-- If `download_assets` output is too noisy, ask the user to paste Figma's cleaner "Copy as SVG" output.
+  - Leave `fill="white"` inside kept `<defs><clipPath>` alone; those are masks.
+- Verify id integrity after cleanup: every `url(#id)` must resolve to a kept element. If embedding the same SVG more than once on a page, suffix gradient/clip ids uniquely per instance and update every `url(#...)` reference, because duplicate ids resolve to the first match.
+- Export the artwork node, not its parent frame. Frame exports pad the `viewBox` with empty space so height-based sizing renders tiny artwork. Crop the `viewBox` to ink/artwork bounds; for height-based sizing, put `style="height:Npx; width:auto; display:block"` on the root `<svg>`.
 - Regex gotcha: `id="X"` contains `d="X"` as a substring. Match `\sd="`, not bare `d="`.
 - Replacing an `<img>` with an embed loses the image's classes/margins; reapply spacing on the embed.
 - Never call `set_text("")` on a Link that contains icon embeds; it can wipe child embeds.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/assets-and-svg.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/assets-and-svg.md
@@ -1,0 +1,62 @@
+# Assets, SVG, And Fonts
+
+Read this before exporting, uploading, or placing images, SVGs, logos, icons, or fonts.
+
+## Figma Extraction
+
+- Pull `get_metadata`, `get_design_context`, and `get_variable_defs` early.
+- Asset URLs from design context live about 7 days; screenshot URLs are short-lived. Download promptly.
+- Read the page/canvas background color from Figma. Do not assume white.
+- For composed mockups or complex product visuals, export the parent node at 2x with `download_assets` and treat it as one image instead of rebuilding every layer.
+
+## Raster Images
+
+- Use the headless Data API asset path first. Do not build around `asset_tool upload_image_by_url`; it is Designer Bridge-gated and may be removed.
+- Download image bytes locally from the Figma export/design-context URL.
+- Compute MD5 of the actual bytes.
+- Call `data_assets_tool create_asset` with `site_id`, `file_name`, and `file_hash`.
+- POST bytes to the returned presigned S3 form: form fields first, file field last.
+- Validate the presigned `policy` is pure base64 ASCII before POSTing:
+
+```bash
+printf '%s' "$POLICY" | grep -q '[^A-Za-z0-9+/=]' && echo "ABORT: non-ASCII in policy"
+```
+
+- Verify the created asset has nonzero size/variants before placing it. If it remains `size:0` or has no variants, report that Webflow accepted the upload but has not processed a renderable asset.
+- Bind images by asset ID with `set_image_asset`, or create the Image with `data_element_builder` and `set_image_asset`.
+- Never rely on raw WHTML `<img src="...">`; it is inserted without a managed Webflow asset.
+- Apply an image-fill class to images inside placeholders: `width:100%; height:100%; object-fit:cover; display:block`.
+- For crisp display, ship a 2x source and constrain it to display size with CSS. Do not depend on the Designer-only HiDPI checkbox.
+- Delete orphaned `size:0` assets when safe.
+
+## Inline SVG Embeds
+
+- Logos, icons, and marks must be inline SVG inside `HtmlEmbed`, not uploaded SVG assets in `<img>`, unless the user explicitly approves fallback.
+- Gradient/complex SVGs placed as `<img>` can render as a filled blob; inline embed avoids that.
+- Create the `HtmlEmbed` first, then set code via `data_element_tool set_settings` with key `"code"` and the raw markup as `static_text`. Do not rely on setting embed code at element creation.
+- To avoid malformed tool-call JSON:
+  - Single-quote SVG attributes.
+  - Collapse whitespace between tags.
+  - Round path coordinates to about 1 decimal.
+  - Hoist shared fill to the root `<svg>` where possible.
+  - Do one SVG per tool call. Around 13 KB is usually reliable; 16-20 KB is risky.
+- Clean Figma SVG exports:
+  - Strip full-page/canvas backing rects.
+  - Strip dashed component-boundary rects.
+  - Remove off-target paths and unused `id` attributes.
+  - Keep ids referenced by `url(#...)` gradients/clips.
+  - Leave `fill="white"` inside `<defs><clipPath>` alone; those are masks.
+- Crop the `viewBox` to artwork bounds. For height-based sizing, put `style="height:Npx; width:auto; display:block"` on the root `<svg>`.
+- If `download_assets` output is too noisy, ask the user to paste Figma's cleaner "Copy as SVG" output.
+- Regex gotcha: `id="X"` contains `d="X"` as a substring. Match `\sd="`, not bare `d="`.
+- Replacing an `<img>` with an embed loses the image's classes/margins; reapply spacing on the embed.
+- Never call `set_text("")` on a Link that contains icon embeds; it can wipe child embeds.
+
+## Fonts
+
+- Upload fonts with `data_fonts_tool`: `create_font` with MD5 `file_hash`, then presigned upload.
+- Source woff2 from Google Fonts `css2` latin endpoint with a desktop User-Agent when needed.
+- Never add Google Fonts `<link>` tags to page/site head after uploading fonts; they create duplicate `@font-face` declarations.
+- Reference fonts by exact family name.
+- First snapshots can show fallback fonts during cold-cache `font-display: swap`. Warm the cache with a throwaway/full-page snapshot and re-snapshot before changing font implementation.
+- Variable-font woff2 files can serve multiple weights; registering each weight against the same source file is acceptable.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/css-rules.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/css-rules.md
@@ -7,6 +7,8 @@ Read this before creating Webflow variables, classes, styles, or responsive over
 - Apply styles with `data_style_tool`, never with the `data_whtml_builder` `css` param. WHTML CSS lands in Designer **Custom properties**, so the result is hard to edit and does not map to native Style-panel controls.
 - Bind Webflow variables with `variable_as_value: "<variable-id>"` from `data_variable_tool`. Do not use raw `var(--collection---token)` strings; they do not render the native variable pill.
 - Only truly non-native CSS belongs in Custom properties: `backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient` backgrounds, parent-state selectors, custom mobile-toggle selectors, and similar CSS Webflow cannot model.
+- Do not use embed `<style>` blocks for normal layout, typography, spacing, backgrounds, dividers, grids, cards, or section styling. That hides styling from the Designer style panel.
+- Do not use `::before` or `::after`. Pseudo-elements are invisible in the Navigator and unselectable in Designer. Build decorative lines, grids, badges, and backgrounds as real elements with native classes.
 
 ## Webflow-Compatible CSS
 
@@ -34,6 +36,7 @@ Read this before creating Webflow variables, classes, styles, or responsive over
 - Use `data_whtml_builder` for DOM/structure only: one root element per action, markup, semantic tags, text, nesting, and class names.
 - To insert multiple sibling sections, use multiple WHTML actions.
 - If a class does not exist, create it with `data_style_tool create_style`; do not define it through WHTML CSS.
+- Create classes before referencing them in WHTML or element class lists. If a custom class exists only as a string in WHTML and no Webflow style exists yet, Webflow can silently drop it, leaving unstyled full-width text or broken layout.
 - `set_style` replaces all classes on an element. Include all intended classes when applying it.
 - `query_elements` style filters are case-insensitive substring matches. Filter results by exact class/type before acting.
 - Capture returned element ids from every insert. Re-find later by exact style/type when possible.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/css-rules.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/css-rules.md
@@ -1,0 +1,50 @@
+# CSS And Build Rules
+
+Read this before creating Webflow variables, classes, styles, or responsive overrides.
+
+## Native Styling Gate
+
+- Apply styles with `data_style_tool`, never with the `data_whtml_builder` `css` param. WHTML CSS lands in Designer **Custom properties**, so the result is hard to edit and does not map to native Style-panel controls.
+- Bind Webflow variables with `variable_as_value: "<variable-id>"` from `data_variable_tool`. Do not use raw `var(--collection---token)` strings; they do not render the native variable pill.
+- Only truly non-native CSS belongs in Custom properties: `backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient` backgrounds, parent-state selectors, custom mobile-toggle selectors, and similar CSS Webflow cannot model.
+
+## Webflow-Compatible CSS
+
+- Use longhand properties. Expand `padding`, `margin`, `border`, `border-radius`, `font`, `background`, `transition`, and `flex`.
+- Use class selectors only. No tag, ID, descendant, or attribute selectors. `:hover` is the only safe pseudo-class in native styles.
+- Emit `grid-row-gap` and `grid-column-gap` even on flex; Webflow stores gaps under those keys.
+- Build desktop-first: base styles apply to all devices, then override downward.
+  - `main`: base desktop
+  - `medium`: 991px and below
+  - `small`: 767px and below
+  - `tiny`: 479px and below
+- Prefer flexbox. Use grid only for true two-dimensional layouts.
+- Avoid unsupported/dropped values: `calc()`, `clamp()`, `min()`, `max()`, `@keyframes`, `@font-face`, multi-layer `box-shadow`, logical props, vendor prefixes.
+- Put inheritable typography once on `.page-wrapper`: font family, color, base size, line height. Use single font names, no fallback stacks.
+
+## Design System And Units
+
+- Follow the selected variable strategy before building sections.
+- Prefer Webflow variables for repeated colors, typography, spacing, and radii unless the user explicitly selected hard-coded output.
+- Follow the selected naming strategy. If using FlowKit, read/reference `webflow-mcp:flowkit-naming`; otherwise use layout/structure-based kebab-case names and never page-prefixed names.
+- Follow the selected unit preference. Default to `px`; convert to `rem` or `em` only when the user chooses that strategy.
+
+## Element Construction
+
+- Use `data_whtml_builder` for DOM/structure only: one root element per action, markup, semantic tags, text, nesting, and class names.
+- To insert multiple sibling sections, use multiple WHTML actions.
+- If a class does not exist, create it with `data_style_tool create_style`; do not define it through WHTML CSS.
+- `set_style` replaces all classes on an element. Include all intended classes when applying it.
+- `query_elements` style filters are case-insensitive substring matches. Filter results by exact class/type before acting.
+- Capture returned element ids from every insert. Re-find later by exact style/type when possible.
+- Element ids are `{component, element}`, where `component` is the page id. Use the matching top-level `pageId`.
+- Combo classes can be ambiguous. When in doubt, prefer one standalone class with full styling.
+
+## Layout Patterns
+
+- Use `repeating-linear-gradient`, not `border-style:dashed`, for dashed accents/dividers/underlines so dash length, gap, opacity, and direction match the design.
+- Decorative overlays must sit behind content. Make `.page-wrapper` a stacking context (`position:relative; z-index:0`) and place overlays at `z-index:-1`.
+- Never use a fixed overlay width wider than the viewport. Prefer `left:0; right:0; width:auto; max-width:<design-width>; margin-left:auto; margin-right:auto`.
+- Replicate interior grid lines too, not just outer edges; check Figma for distributed columns.
+- A fixed nav lets the first section sit under the bar; add top-padding to clear it. Sticky nav reserves space.
+- Suppress Designer-only `.wf-empty` affordances on decorative empty normal DivBlocks with a dimension-giving style in the active breakpoint. For custom-tag empty elements, add a child or use a normal DivBlock.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/navbar.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/navbar.md
@@ -41,7 +41,7 @@ Make `.nav` or `.nav-inner` `position:relative` so the dropdown anchors to the b
 
 ## Behavior
 
-Keep desktop visual styling as normal Webflow classes. Put responsive/toggle behavior in one component-scoped HtmlEmbed inside the nav root, so it travels if converted to a component.
+Keep desktop visual styling as normal Webflow classes. Put CSS-only responsive/toggle behavior in one component-scoped HtmlEmbed inside the nav root, so it travels if converted to a component. Do **not** use JavaScript for custom navbar behavior.
 
 ```html
 <style>
@@ -59,4 +59,4 @@ Keep desktop visual styling as normal Webflow classes. Put responsive/toggle beh
 </style>
 ```
 
-Pure CSS is zero-JS and publish-safe, but does not set `aria-expanded` or close on outside click. If the client needs those, use a small JS toggle; guarantee the open-state CSS in the same embed because unused combo classes can be stripped from published CSS.
+Pure CSS is zero-JS and publish-safe. It does not set `aria-expanded` or close on outside click; tell the user that tradeoff rather than adding JavaScript.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/navbar.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/navbar.md
@@ -1,0 +1,62 @@
+# Navbar
+
+Read this before building a navigation bar.
+
+Webflow's native Navbar component cannot be created via API/WHTML. WHTML can produce generic blocks with `w-*` class names, but not the real component JS/CSS. Build a semantic custom nav or ask the user to add the native element in Designer.
+
+## Required Prompt
+
+Ask which breakpoint should collapse to hamburger:
+
+- 3-4 short links, no/short CTA: recommend mobile landscape (`767`) or mobile portrait (`479`).
+- 5+ links, long labels, or prominent CTA: recommend tablet (`991`) so the bar does not crowd.
+
+State the recommendation and reason, then use the user's choice.
+
+## Structure
+
+Build with custom tags so it is semantic and Designer-editable:
+
+```html
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">...</a>
+    <input type="checkbox" id="nav-toggle" class="nav-cb">
+    <label for="nav-toggle" class="nav-burger">
+      <span class="nav-burger-bar"></span>
+      <span class="nav-burger-bar"></span>
+      <span class="nav-burger-bar"></span>
+    </label>
+    <div class="nav-menu">
+      <a class="nav-link" href="#">...</a>
+      <a class="btn" href="#">CTA</a>
+    </div>
+  </div>
+</nav>
+```
+
+The checkbox must be a previous sibling of `.nav-menu` so `:checked ~ .nav-menu` works. Order: brand, checkbox, burger, menu.
+
+Make `.nav` or `.nav-inner` `position:relative` so the dropdown anchors to the bar. Use custom-tag `input` / `label`, not the Form Checkbox element, because Webflow's `.w-checkbox` wrapper breaks the sibling chain.
+
+## Behavior
+
+Keep desktop visual styling as normal Webflow classes. Put responsive/toggle behavior in one component-scoped HtmlEmbed inside the nav root, so it travels if converted to a component.
+
+```html
+<style>
+  .nav-cb{ position:absolute; width:1px; height:1px; opacity:0; pointer-events:none; }
+  .nav-burger{ display:none; }
+  @media screen and (max-width:{BP}px){
+    .nav-burger{ display:flex; flex-direction:column; row-gap:5px; cursor:pointer; }
+    .nav-menu{
+      display:none; position:absolute; top:100%; left:0; right:0;
+      flex-direction:column; align-items:flex-start; row-gap:4px;
+      padding:16px 24px; background:#fff; box-shadow:0 10px 24px rgba(0,0,0,.10);
+    }
+    .nav-cb:checked ~ .nav-menu{ display:flex; }
+  }
+</style>
+```
+
+Pure CSS is zero-JS and publish-safe, but does not set `aria-expanded` or close on outside click. If the client needs those, use a small JS toggle; guarantee the open-state CSS in the same embed because unused combo classes can be stripped from published CSS.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
@@ -11,6 +11,7 @@ Read this before responsive work, visual QA, snapshots, or publish/review.
   - `tiny`: 479px and below
 - Desktop-first: set base, then override downward.
 - Use structural verification between visual checks: `query_elements`, `query_styles`, exact class/type filtering.
+- Structural verification is not enough to call a build done. It can prove elements/classes exist, but not that the rendered layout is correct.
 
 ## Designer Bridge And Snapshots
 
@@ -32,6 +33,14 @@ Read this before responsive work, visual QA, snapshots, or publish/review.
 - Page branching APIs may be unavailable (`create_branch` / `list_branches` can 404). Substitute `create_page` with `duplicateOf` to clone a page as an experiment.
 - For reversible enhancements, layer the new thing over a static fallback rather than replacing it.
 - Figma component instances often carry repeated default labels. Confirm intended labels with the user.
+- Before saying a capability "can't" be done, test the relevant MCP tool path. If you cannot test, say it is untested and be precise about whether the limitation is Webflow itself, the MCP API, or the current tool surface.
+- Avoid broad tag/global style tests on real pages. If testing a risky capability, use an isolated duplicate page or disposable element and revert immediately.
+- After WHTML insertion, verify that expected classes survived and resolve to existing Webflow styles. Missing styles can leave rendered content unstyled even when the DOM exists.
+
+## Done Criteria
+
+- Do not call the build done until rendered output is visually checked with Designer Bridge, preview, or explicit user confirmation.
+- If visual verification is blocked, report exactly what is unverified and ask the user to check it.
 
 ## Publish
 

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
@@ -1,0 +1,47 @@
+# Verification And Responsive QA
+
+Read this before responsive work, visual QA, snapshots, or publish/review.
+
+## Responsive
+
+- Responsive work is headless: use `data_style_tool update_style` with breakpoint ids.
+  - `main`: base desktop
+  - `medium`: 991px and below
+  - `small`: 767px and below
+  - `tiny`: 479px and below
+- Desktop-first: set base, then override downward.
+- Use structural verification between visual checks: `query_elements`, `query_styles`, exact class/type filtering.
+
+## Designer Bridge And Snapshots
+
+- `element_snapshot_tool` requires Designer tab open and foregrounded.
+- Snapshots are desktop viewport only. They do not simulate responsive/mobile.
+- Snapshots do not execute embeds, WebGL, `backdrop-filter`, or custom code behavior.
+- If a snapshot or `designer_tool` returns `status:false`, the bridge is likely disconnected, backgrounded, idle, or cold. Ask the user to foreground the Designer tab and retry.
+- Large composites can fail transiently when bridge is cold or page is very tall; retry before assuming the build is broken.
+
+## Snapshot Traps
+
+- Isolated-section snapshots do not include sibling overlays such as page-level grids/backgrounds. Verify overlays/layering with a full-page composite of the top-level wrapper.
+- Transparent regions render as black in isolated snapshots. On the page, the page background shows through.
+- `position:fixed` elements can render unreliably in composites. Confirm fixed-element clearance in preview/live.
+- First snapshot of a session can show fallback fonts because uploaded fonts load asynchronously. Warm cache with a throwaway/full-page snapshot and re-snapshot before changing font implementation.
+
+## Structural Gotchas
+
+- Page branching APIs may be unavailable (`create_branch` / `list_branches` can 404). Substitute `create_page` with `duplicateOf` to clone a page as an experiment.
+- For reversible enhancements, layer the new thing over a static fallback rather than replacing it.
+- Figma component instances often carry repeated default labels. Confirm intended labels with the user.
+
+## Publish
+
+- Do not publish by default.
+- If the user wants a review link, publish to `.webflow.io` before any custom domain.
+- You cannot fetch `*.webflow.io` from the agent because it is robots-blocked. Ask the user to confirm:
+  - embed behavior
+  - custom code
+  - blur/backdrop effects
+  - WebGL/canvas
+  - animation
+  - mobile/responsive widths
+- Never claim those behaviors are verified from your side.


### PR DESCRIPTION
adds a figma-to-webflow skill for translating figma designs into webflow pages.