### PR TITLE
feat(skills): add webflow-mcp:figma-to-webflow skill for translating Figma designs into Webflow projects and update version numbers to 1.0.7

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Production-ready agent skills for Webflow - CMS management, site auditing, Designer tools, Code Components, CLI workflows, and safe publishing",
   "author": {
     "name": "Webflow",
@@ -20,6 +20,8 @@
     "asset-optimization",
     "designer",
     "designer-tools",
+    "figma",
+    "figma-to-webflow",
     "components",
     "code-components",
     "cli",

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All skills ship from the single `webflow-skills` plugin.
 | webflow-mcp:custom-code-management | Manage tracking scripts and custom code safely |
 | webflow-mcp:flowkit-naming | Apply Webflow's official FlowKit CSS naming conventions |
 | webflow-mcp:designer-tools | Build and manage page structure, elements, components, and styles in Webflow Designer |
+| webflow-mcp:figma-to-webflow | Build pages, sections, components, or full sites from Figma designs using Figma MCP and Webflow MCP |
 
 ### Webflow CLI Skills
 

--- a/plugins/webflow-skills/.claude-plugin/plugin.json
+++ b/plugins/webflow-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "skills": "./skills/"
 }

--- a/plugins/webflow-skills/.codex-plugin/plugin.json
+++ b/plugins/webflow-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes.",
   "author": {
     "name": "Webflow",
@@ -24,6 +24,8 @@
     "designer-tools",
     "components",
     "code-components",
+    "figma",
+    "figma-to-webflow",
     "cli",
     "devlink",
     "webflow-cloud",
@@ -48,6 +50,7 @@
       "Find and fix broken links on my site",
       "Prepare a safe publish checklist",
       "Inspect the current Designer page structure",
+      "Build this Figma design in Webflow",
       "Create a new Webflow Code Component",
       "Deploy a Webflow Cloud app"
     ],

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: webflow-mcp:figma-to-webflow
+description: >-
+  Build a Webflow page, section, component, or full site from a Figma design
+  using the Figma MCP and the Webflow MCP (Designer Bridge + Data API). Use
+  whenever translating a Figma file/frame into Webflow, building directly in a
+  Webflow project, or implementing a design as live Webflow elements/styles
+  (not a copy-paste fragment). Triggers: "build this Figma in Webflow",
+  "Figma to Webflow", "implement this design in Webflow", a figma.com URL +
+  a Webflow site, "recreate this in my Webflow project".
+---
+
+# Figma → Webflow
+
+Translate a Figma design into a live Webflow project: real elements, styles,
+assets, fonts, and (optionally) custom code + interactions.
+
+## Instructions
+
+Follow this order exactly. When a step says to read a reference file, read it
+before doing that work; those files contain the failure modes for that step.
+
+## Non-Negotiable Gates
+
+Treat these as build gates, not suggestions. If you cannot satisfy one, stop
+and explain the tradeoff instead of silently substituting.
+
+- **Bridge gate:** Designer Bridge is the default build mode. If selected, provide or request the Designer launch link and wait for the user to open the project with the Designer tab foregrounded before bridge-dependent steps. If the bridge disconnects, keep structural work headless and reconnect before snapshots/canvas inspection.
+- **Native style gate:** apply styles with `data_style_tool`, never with the `data_whtml_builder` `css` param or raw `var()` strings. Otherwise styles land in Custom properties instead of native controls. Bind Webflow variables with `variable_as_value`.
+- **Visible element gate:** build with real Designer-visible elements and native classes. Do not use embed `<style>` blocks, `::before` / `::after`, or other hidden constructs for normal layout/decorative elements.
+- **Class existence gate:** create every class with `data_style_tool create_style` before using it in WHTML/element class lists. Webflow can silently drop class names that do not exist yet.
+- **Variables gate:** decide the Webflow variable/design-system strategy before creating styles. Do not hard-code repeated colors/type/spacing/radii unless the user explicitly chooses hard-coded output.
+- **Vector gate:** logos, icons, and marks must be inline SVG embeds, not PNG/JPG uploads, unless the user explicitly approves raster fallback.
+- **Raster quality gate:** hero/product/mockup images must use a confirmed 2x source where crispness matters.
+- **Dashed accent gate:** dashed lines, dividers, grids, accents, and underlines must use `repeating-linear-gradient`, not `border-style:dashed`, unless the user explicitly accepts browser-default dash rhythm.
+- **Navbar gate:** custom navbar mobile behavior must be CSS-only, not JavaScript. Use the checkbox/sibling-selector pattern in `references/navbar.md`.
+- **Verification gate:** never call a build done until you have verified rendered output. If visual verification is blocked, say what is unverified and ask the user to check it.
+- **Capability gate:** do not assert that Webflow or MCP "can't" do something until you have tested the relevant tool path or clearly label it as untested.
+- **Publish gate:** do not publish by default. Offer `.webflow.io` publish only after build/review, and only proceed on explicit user confirmation.
+
+## Tool Surfaces
+
+| Surface | Examples | Needs Designer open? |
+|---|---|---|
+| **Data API** (headless) | `data_whtml_builder`, `data_element_builder`, `data_element_tool`, `data_style_tool`, `data_fonts_tool`, `data_pages_tool`, `data_scripts_tool`, `data_assets_tool`, publish | No |
+| **Designer Bridge** | `element_snapshot_tool`, `designer_tool` canvas/selection/navigation, `asset_tool upload_image_by_url` | **Yes — Designer tab open AND foregrounded** |
+
+- Call `webflow_guide_tool` once before other Webflow tools. Confirm auth/site with `whoami` + `get_site`.
+- Prefer bridge-assisted builds by default for better visual feedback, while still using `data_*` tools for DOM, classes/styles, text, semantic tags, responsive overrides, fonts, scripts, pages, and asset records.
+- If Designer is disconnected, continue structural work headlessly with `query_styles`, `get_all_elements`, and `query_elements`; reconnect the bridge for snapshots, canvas inspection, and any still-required bridge-gated image processing fallback.
+- If a bridge tool returns `status:false` or "Unable to connect to Webflow Designer," share the launch link and ask the user to open the Designer **and keep that browser tab in the foreground** — it idles/disconnects when backgrounded. Retry before assuming anything broke.
+
+## Workflow
+
+### 1. Gather And Decide
+
+1. Use Figma MCP:
+   - `get_metadata` for structure.
+   - `get_design_context` for major frames/sections.
+   - `get_variable_defs` for colors, type, spacing, radii.
+   - Read page/canvas background; do not assume white.
+2. Use Webflow MCP:
+   - `webflow_guide_tool` first.
+   - Confirm target site/page and inspect existing variables/styles.
+3. Ask the required setup prompts below.
+4. Confirm ambiguous design intent before building. If Figma component instances contain repeated placeholder labels, ask for intended copy instead of copying placeholders.
+
+### Required Prompts
+
+Before creating Webflow variables, classes, or CSS, ask these four questions:
+
+- **Build mode:** Designer Bridge during build (default, better visual QA; requires Designer tab open/foregrounded) or headless first (faster, structural checks only until bridge needed).
+- **Variables/design system:** read existing variables and create missing ones (default), create a new design system from scratch, use existing variables only, or hard-code with no Webflow variables.
+- **Style naming:** FlowKit naming (default; reference `webflow-mcp:flowkit-naming`), existing Webflow design-system naming, or clear semantic kebab-case names.
+- **Units:** `px` (default), `rem`, or `em`. Keep units consistent; only mix when there is a clear reason.
+
+If the user does not choose, use the defaults above. For a blank site, recommend creating a new design system from scratch and explain why.
+
+### 2. Build Foundations And Sections
+
+Before creating variables/classes/styles, read [CSS rules](references/css-rules.md).
+
+1. Create or map Webflow variables according to the selected strategy.
+2. Create reusable primitives first: page wrapper, containers, typography, spacing, buttons, image-fill, cards, nav.
+3. Create needed classes with `data_style_tool create_style` before referencing them in WHTML/element class lists.
+4. Use `data_whtml_builder` for DOM/structure only: one root section per action, semantic tags, nesting, text, and existing class names.
+5. Style with `data_style_tool update_style`. Repeat: do **not** use the WHTML `css` param or embed `<style>` blocks for normal styling.
+6. Capture returned element ids. Re-find later with `query_elements`, then filter by exact class/type before acting.
+7. Build in section-sized batches. Prefer structural verification with `query_elements` / `query_styles` between visual checks.
+
+### 3. Attach Assets
+
+Before handling images or vectors, read [Assets and SVG](references/assets-and-svg.md).
+
+1. Use `data_assets_tool create_asset` for raster assets. Download source bytes locally, compute MD5, POST to presigned S3, then verify nonzero size/variants before placement.
+2. For hero/product/mockup images, confirm 2x source before placement.
+3. Bind images by asset ID with `set_image_asset`; never rely on raw `<img src="...">`.
+4. Inline vector marks as `HtmlEmbed` SVGs and set embed code with `data_element_tool set_settings`.
+5. Upload fonts with `data_fonts_tool`; never add Google Fonts `<link>` tags to head.
+
+### 4. Navbar And Custom Behavior
+
+If the build includes a navbar, read [Navbar](references/navbar.md) before building it.
+
+- Ask which breakpoint should collapse to hamburger.
+- Webflow native Navbar cannot be created via API/WHTML. Build a semantic custom nav or ask the user to add the native element in Designer.
+- Put CSS-only component behavior in an HtmlEmbed inside the component root. Do not use JavaScript for the custom navbar.
+
+### 5. Responsive And QA
+
+Before responsive/final verification, read [Verification](references/verification.md).
+
+1. Use `data_style_tool update_style` with breakpoint ids (`main`, `medium`, `small`, `tiny`). Desktop-first: set base, override downward.
+2. If Designer Bridge is selected, snapshot groups/wrappers rather than every element. Keep the Designer tab foregrounded.
+3. Verify overlays/layering with a full-page composite, not isolated-section snapshots.
+4. Do not trust first snapshots for fonts; warm cache and re-snapshot before changing font implementation.
+5. Test tool capabilities before asserting limitations. If you cannot test, say "untested" and describe the uncertainty.
+6. Do not claim embed behavior, custom code, blur, WebGL, animation, or mobile widths are verified from your side. Ask the user to confirm in preview/published site.
+7. Offer publish/review next steps. Default remains **no publish**.
+
+## Checklist before declaring done
+
+- [ ] Required reference files were read at their point of use.
+- [ ] All CSS longhand; correct breakpoints; flexbox-first.
+- [ ] Styles applied via `data_style_tool` (native controls), variables bound with `variable_as_value`, and only truly non-native CSS (`backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient`, etc.) left as custom properties.
+- [ ] All class names used in WHTML/element class lists exist as Webflow styles; none were silently dropped.
+- [ ] No embed `<style>` blocks or `::before` / `::after` pseudo-elements used for normal layout/decorative elements.
+- [ ] Build mode followed: bridge-assisted by default with Designer tab open and foregrounded, or headless-first if the user chose it.
+- [ ] Webflow variables handled according to the selected strategy; repeated colors/type/spacing/radii are mapped or created unless hard-coding was explicitly selected.
+- [ ] Images attached by asset ID (not orphan `<img src>`); 2× source confirmed where crispness matters.
+- [ ] Vector marks are clean inline-SVG embeds (backgrounds stripped), or user explicitly approved raster fallback.
+- [ ] Dashed accents/dividers/grids use `repeating-linear-gradient`, not `border-style:dashed`, unless user explicitly approved browser-default dashes.
+- [ ] Fonts uploaded + referenced by exact family name; temp `<head>` link removed.
+- [ ] Runtime-toggled classes have guaranteed CSS (not stripped).
+- [ ] Responsive overrides at medium/small/tiny.
+- [ ] Rendered output verified visually, or unverified items clearly reported to the user.
+- [ ] No untested capability limitation was stated as fact.
+- [ ] If published to subdomain, user asked to confirm anything you can't self-verify (embeds, WebGL, blur, mobile).

--- a/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/SKILL.md
@@ -25,7 +25,7 @@ before doing that work; those files contain the failure modes for that step.
 Treat these as build gates, not suggestions. If you cannot satisfy one, stop
 and explain the tradeoff instead of silently substituting.
 
-- **Bridge gate:** Designer Bridge is the default build mode. If selected, provide or request the Designer launch link and wait for the user to open the project with the Designer tab foregrounded before bridge-dependent steps. If the bridge disconnects, keep structural work headless and reconnect before snapshots/canvas inspection.
+- **Bridge gate:** Designer Bridge is the default build mode. If selected, provide the Designer launch link (opens Designer with the MCP Bridge App) and wait for the user to open it with that tab foregrounded before bridge-dependent steps. If the bridge disconnects, keep structural work headless and reconnect before snapshots/canvas inspection.
 - **Native style gate:** apply styles with `data_style_tool`, never with the `data_whtml_builder` `css` param or raw `var()` strings. Otherwise styles land in Custom properties instead of native controls. Bind Webflow variables with `variable_as_value`.
 - **Visible element gate:** build with real Designer-visible elements and native classes. Do not use embed `<style>` blocks, `::before` / `::after`, or other hidden constructs for normal layout/decorative elements.
 - **Class existence gate:** create every class with `data_style_tool create_style` before using it in WHTML/element class lists. Webflow can silently drop class names that do not exist yet.
@@ -48,7 +48,7 @@ and explain the tradeoff instead of silently substituting.
 - Call `webflow_guide_tool` once before other Webflow tools. Confirm auth/site with `whoami` + `get_site`.
 - Prefer bridge-assisted builds by default for better visual feedback, while still using `data_*` tools for DOM, classes/styles, text, semantic tags, responsive overrides, fonts, scripts, pages, and asset records.
 - If Designer is disconnected, continue structural work headlessly with `query_styles`, `get_all_elements`, and `query_elements`; reconnect the bridge for snapshots, canvas inspection, and any still-required bridge-gated image processing fallback.
-- If a bridge tool returns `status:false` or "Unable to connect to Webflow Designer," share the launch link and ask the user to open the Designer **and keep that browser tab in the foreground** — it idles/disconnects when backgrounded. Retry before assuming anything broke.
+- If a bridge tool returns `status:false` or "Unable to connect to Webflow Designer," provide the Designer launch link (opens Designer with the MCP Bridge App) and ask the user to open it **and keep that browser tab in the foreground** — it idles/disconnects when backgrounded. Retry before assuming anything broke.
 
 ## Workflow
 

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/assets-and-svg.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/assets-and-svg.md
@@ -1,0 +1,68 @@
+# Assets, SVG, And Fonts
+
+Read this before exporting, uploading, or placing images, SVGs, logos, icons, or fonts.
+
+## Figma Extraction
+
+- Pull `get_metadata`, `get_design_context`, and `get_variable_defs` early.
+- Asset URLs from design context live about 7 days; screenshot URLs are short-lived. Download promptly.
+- Read the page/canvas background color from Figma. Do not assume white.
+- For composed mockups or complex product visuals, export the parent node at 2x with `download_assets` and treat it as one image instead of rebuilding every layer.
+
+## Raster Images
+
+- Use the headless Data API asset path first. Do not build around `asset_tool upload_image_by_url`; it is Designer Bridge-gated and may be removed.
+- Download image bytes locally from the Figma export/design-context URL.
+- Compute MD5 of the actual bytes.
+- Call `data_assets_tool create_asset` with `site_id`, `file_name`, and `file_hash`.
+- POST bytes to the returned presigned S3 form: form fields first, file field last.
+- Validate the presigned `policy` is pure base64 ASCII before POSTing:
+
+```bash
+printf '%s' "$POLICY" | grep -q '[^A-Za-z0-9+/=]' && echo "ABORT: non-ASCII in policy"
+```
+
+- Verify the created asset has nonzero size/variants before placing it. If it remains `size:0` or has no variants, report that Webflow accepted the upload but has not processed a renderable asset.
+- Bind images by asset ID with `set_image_asset`, or create the Image with `data_element_builder` and `set_image_asset`.
+- Never rely on raw WHTML `<img src="...">`; it is inserted without a managed Webflow asset.
+- Apply an image-fill class to images inside placeholders: `width:100%; height:100%; object-fit:cover; display:block`.
+- For crisp display, ship a 2x source and constrain it to display size with CSS. Do not depend on the Designer-only HiDPI checkbox.
+- Delete orphaned `size:0` assets when safe.
+
+## Inline SVG Embeds
+
+- Logos, icons, and marks must be inline SVG inside `HtmlEmbed`, not uploaded SVG assets in `<img>`, unless the user explicitly approves fallback.
+- Gradient/complex SVGs placed as `<img>` can render as a filled blob; inline embed avoids that.
+- Prefer Figma right-click **Copy as SVG** for logos/marks/icons; it usually gives clean artwork with tight bounds. Use MCP `download_assets` / design-context SVG export only when clipboard output is unavailable, and expect scaffolding to strip.
+- Create the `HtmlEmbed` first, then set code via `data_element_tool set_settings` with key `"code"` as `static_text`.
+- Pass the SVG as the literal `static_text.value` of the `code` setting and let the tool layer encode it. Do not hand-build, pre-escape, or wrap the arguments in a raw/blob form. If you get "could not be parsed as JSON," the tool call is malformed; fix the call shape, do not shrink the SVG.
+- There is no ~13 KB per-SVG `set_settings` ceiling; 20 KB can pass as a string value. The real practical limit is Webflow Designer's HTML Embed UI, about 10,000 characters. Data API embeds over ~10k can render, but they are not safely hand-editable in Designer and may be truncated if opened/re-saved. If the embed must remain Designer-editable, reduce it below ~10k.
+- Optimize only as needed:
+  - Single-quote SVG attributes.
+  - Collapse whitespace between tags.
+  - Hoist shared fill to the root `<svg>` where possible.
+  - Keep vectorized wordmark text as paths; never substitute live text for logo text unless the user explicitly wants editable text.
+  - Never round coordinates to integers; it destroys curves on small artwork. One decimal is the floor, and only round if needed to fit the ~10k Designer-editable limit.
+- Clean MCP/Figma SVG exports:
+  - Strip full-canvas backing `<rect>` elements by oversized dimensions, not just fill; some inherit the root fill and render as a giant dark box.
+  - Strip page-fill `<path>` elements, often `#F4F1FD` or `#F3F5F7`.
+  - Strip dashed component-boundary `<rect stroke="#9747FF" stroke-dasharray=...>`.
+  - Strip nested wrapper `<g id>` elements when not needed.
+  - Strip `<defs><clipPath>` scaffolding only when no kept artwork references it.
+  - Remove off-target paths and unused `id` attributes.
+  - Keep ids referenced by `url(#...)` gradients/clips.
+  - Leave `fill="white"` inside kept `<defs><clipPath>` alone; those are masks.
+- Verify id integrity after cleanup: every `url(#id)` must resolve to a kept element. If embedding the same SVG more than once on a page, suffix gradient/clip ids uniquely per instance and update every `url(#...)` reference, because duplicate ids resolve to the first match.
+- Export the artwork node, not its parent frame. Frame exports pad the `viewBox` with empty space so height-based sizing renders tiny artwork. Crop the `viewBox` to ink/artwork bounds; for height-based sizing, put `style="height:Npx; width:auto; display:block"` on the root `<svg>`.
+- Regex gotcha: `id="X"` contains `d="X"` as a substring. Match `\sd="`, not bare `d="`.
+- Replacing an `<img>` with an embed loses the image's classes/margins; reapply spacing on the embed.
+- Never call `set_text("")` on a Link that contains icon embeds; it can wipe child embeds.
+
+## Fonts
+
+- Upload fonts with `data_fonts_tool`: `create_font` with MD5 `file_hash`, then presigned upload.
+- Source woff2 from Google Fonts `css2` latin endpoint with a desktop User-Agent when needed.
+- Never add Google Fonts `<link>` tags to page/site head after uploading fonts; they create duplicate `@font-face` declarations.
+- Reference fonts by exact family name.
+- First snapshots can show fallback fonts during cold-cache `font-display: swap`. Warm the cache with a throwaway/full-page snapshot and re-snapshot before changing font implementation.
+- Variable-font woff2 files can serve multiple weights; registering each weight against the same source file is acceptable.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/css-rules.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/css-rules.md
@@ -1,0 +1,53 @@
+# CSS And Build Rules
+
+Read this before creating Webflow variables, classes, styles, or responsive overrides.
+
+## Native Styling Gate
+
+- Apply styles with `data_style_tool`, never with the `data_whtml_builder` `css` param. WHTML CSS lands in Designer **Custom properties**, so the result is hard to edit and does not map to native Style-panel controls.
+- Bind Webflow variables with `variable_as_value: "<variable-id>"` from `data_variable_tool`. Do not use raw `var(--collection---token)` strings; they do not render the native variable pill.
+- Only truly non-native CSS belongs in Custom properties: `backdrop-filter`, `aspect-ratio`, `repeating-linear-gradient` backgrounds, parent-state selectors, custom mobile-toggle selectors, and similar CSS Webflow cannot model.
+- Do not use embed `<style>` blocks for normal layout, typography, spacing, backgrounds, dividers, grids, cards, or section styling. That hides styling from the Designer style panel.
+- Do not use `::before` or `::after`. Pseudo-elements are invisible in the Navigator and unselectable in Designer. Build decorative lines, grids, badges, and backgrounds as real elements with native classes.
+
+## Webflow-Compatible CSS
+
+- Use longhand properties. Expand `padding`, `margin`, `border`, `border-radius`, `font`, `background`, `transition`, and `flex`.
+- Use class selectors only. No tag, ID, descendant, or attribute selectors. `:hover` is the only safe pseudo-class in native styles.
+- Emit `grid-row-gap` and `grid-column-gap` even on flex; Webflow stores gaps under those keys.
+- Build desktop-first: base styles apply to all devices, then override downward.
+  - `main`: base desktop
+  - `medium`: 991px and below
+  - `small`: 767px and below
+  - `tiny`: 479px and below
+- Prefer flexbox. Use grid only for true two-dimensional layouts.
+- Avoid unsupported/dropped values: `calc()`, `clamp()`, `min()`, `max()`, `@keyframes`, `@font-face`, multi-layer `box-shadow`, logical props, vendor prefixes.
+- Put inheritable typography once on `.page-wrapper`: font family, color, base size, line height. Use single font names, no fallback stacks.
+
+## Design System And Units
+
+- Follow the selected variable strategy before building sections.
+- Prefer Webflow variables for repeated colors, typography, spacing, and radii unless the user explicitly selected hard-coded output.
+- Follow the selected naming strategy. If using FlowKit, read/reference `webflow-mcp:flowkit-naming`; otherwise use layout/structure-based kebab-case names and never page-prefixed names.
+- Follow the selected unit preference. Default to `px`; convert to `rem` or `em` only when the user chooses that strategy.
+
+## Element Construction
+
+- Use `data_whtml_builder` for DOM/structure only: one root element per action, markup, semantic tags, text, nesting, and class names.
+- To insert multiple sibling sections, use multiple WHTML actions.
+- If a class does not exist, create it with `data_style_tool create_style`; do not define it through WHTML CSS.
+- Create classes before referencing them in WHTML or element class lists. If a custom class exists only as a string in WHTML and no Webflow style exists yet, Webflow can silently drop it, leaving unstyled full-width text or broken layout.
+- `set_style` replaces all classes on an element. Include all intended classes when applying it.
+- `query_elements` style filters are case-insensitive substring matches. Filter results by exact class/type before acting.
+- Capture returned element ids from every insert. Re-find later by exact style/type when possible.
+- Element ids are `{component, element}`, where `component` is the page id. Use the matching top-level `pageId`.
+- Combo classes can be ambiguous. When in doubt, prefer one standalone class with full styling.
+
+## Layout Patterns
+
+- Use `repeating-linear-gradient`, not `border-style:dashed`, for dashed accents/dividers/underlines so dash length, gap, opacity, and direction match the design.
+- Decorative overlays must sit behind content. Make `.page-wrapper` a stacking context (`position:relative; z-index:0`) and place overlays at `z-index:-1`.
+- Never use a fixed overlay width wider than the viewport. Prefer `left:0; right:0; width:auto; max-width:<design-width>; margin-left:auto; margin-right:auto`.
+- Replicate interior grid lines too, not just outer edges; check Figma for distributed columns.
+- A fixed nav lets the first section sit under the bar; add top-padding to clear it. Sticky nav reserves space.
+- Suppress Designer-only `.wf-empty` affordances on decorative empty normal DivBlocks with a dimension-giving style in the active breakpoint. For custom-tag empty elements, add a child or use a normal DivBlock.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/navbar.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/navbar.md
@@ -1,0 +1,62 @@
+# Navbar
+
+Read this before building a navigation bar.
+
+Webflow's native Navbar component cannot be created via API/WHTML. WHTML can produce generic blocks with `w-*` class names, but not the real component JS/CSS. Build a semantic custom nav or ask the user to add the native element in Designer.
+
+## Required Prompt
+
+Ask which breakpoint should collapse to hamburger:
+
+- 3-4 short links, no/short CTA: recommend mobile landscape (`767`) or mobile portrait (`479`).
+- 5+ links, long labels, or prominent CTA: recommend tablet (`991`) so the bar does not crowd.
+
+State the recommendation and reason, then use the user's choice.
+
+## Structure
+
+Build with custom tags so it is semantic and Designer-editable:
+
+```html
+<nav class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">...</a>
+    <input type="checkbox" id="nav-toggle" class="nav-cb">
+    <label for="nav-toggle" class="nav-burger">
+      <span class="nav-burger-bar"></span>
+      <span class="nav-burger-bar"></span>
+      <span class="nav-burger-bar"></span>
+    </label>
+    <div class="nav-menu">
+      <a class="nav-link" href="#">...</a>
+      <a class="btn" href="#">CTA</a>
+    </div>
+  </div>
+</nav>
+```
+
+The checkbox must be a previous sibling of `.nav-menu` so `:checked ~ .nav-menu` works. Order: brand, checkbox, burger, menu.
+
+Make `.nav` or `.nav-inner` `position:relative` so the dropdown anchors to the bar. Use custom-tag `input` / `label`, not the Form Checkbox element, because Webflow's `.w-checkbox` wrapper breaks the sibling chain.
+
+## Behavior
+
+Keep desktop visual styling as normal Webflow classes. Put CSS-only responsive/toggle behavior in one component-scoped HtmlEmbed inside the nav root, so it travels if converted to a component. Do **not** use JavaScript for custom navbar behavior.
+
+```html
+<style>
+  .nav-cb{ position:absolute; width:1px; height:1px; opacity:0; pointer-events:none; }
+  .nav-burger{ display:none; }
+  @media screen and (max-width:{BP}px){
+    .nav-burger{ display:flex; flex-direction:column; row-gap:5px; cursor:pointer; }
+    .nav-menu{
+      display:none; position:absolute; top:100%; left:0; right:0;
+      flex-direction:column; align-items:flex-start; row-gap:4px;
+      padding:16px 24px; background:#fff; box-shadow:0 10px 24px rgba(0,0,0,.10);
+    }
+    .nav-cb:checked ~ .nav-menu{ display:flex; }
+  }
+</style>
+```
+
+Pure CSS is zero-JS and publish-safe. It does not set `aria-expanded` or close on outside click; tell the user that tradeoff rather than adding JavaScript.

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
@@ -18,7 +18,7 @@ Read this before responsive work, visual QA, snapshots, or publish/review.
 - `element_snapshot_tool` requires Designer tab open and foregrounded.
 - Snapshots are desktop viewport only. They do not simulate responsive/mobile.
 - Snapshots do not execute embeds, WebGL, `backdrop-filter`, or custom code behavior.
-- If a snapshot or `designer_tool` returns `status:false`, the bridge is likely disconnected, backgrounded, idle, or cold. Ask the user to foreground the Designer tab and retry.
+- If a snapshot or `designer_tool` returns `status:false`, the bridge is likely disconnected, backgrounded, idle, or cold. Provide the Designer launch link (opens Designer with the MCP Bridge App), ask the user to open it and keep that tab foregrounded, then retry.
 - Large composites can fail transiently when bridge is cold or page is very tall; retry before assuming the build is broken.
 
 ## Snapshot Traps

--- a/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
+++ b/plugins/webflow-skills/skills/figma-to-webflow/references/verification.md
@@ -1,0 +1,56 @@
+# Verification And Responsive QA
+
+Read this before responsive work, visual QA, snapshots, or publish/review.
+
+## Responsive
+
+- Responsive work is headless: use `data_style_tool update_style` with breakpoint ids.
+  - `main`: base desktop
+  - `medium`: 991px and below
+  - `small`: 767px and below
+  - `tiny`: 479px and below
+- Desktop-first: set base, then override downward.
+- Use structural verification between visual checks: `query_elements`, `query_styles`, exact class/type filtering.
+- Structural verification is not enough to call a build done. It can prove elements/classes exist, but not that the rendered layout is correct.
+
+## Designer Bridge And Snapshots
+
+- `element_snapshot_tool` requires Designer tab open and foregrounded.
+- Snapshots are desktop viewport only. They do not simulate responsive/mobile.
+- Snapshots do not execute embeds, WebGL, `backdrop-filter`, or custom code behavior.
+- If a snapshot or `designer_tool` returns `status:false`, the bridge is likely disconnected, backgrounded, idle, or cold. Ask the user to foreground the Designer tab and retry.
+- Large composites can fail transiently when bridge is cold or page is very tall; retry before assuming the build is broken.
+
+## Snapshot Traps
+
+- Isolated-section snapshots do not include sibling overlays such as page-level grids/backgrounds. Verify overlays/layering with a full-page composite of the top-level wrapper.
+- Transparent regions render as black in isolated snapshots. On the page, the page background shows through.
+- `position:fixed` elements can render unreliably in composites. Confirm fixed-element clearance in preview/live.
+- First snapshot of a session can show fallback fonts because uploaded fonts load asynchronously. Warm cache with a throwaway/full-page snapshot and re-snapshot before changing font implementation.
+
+## Structural Gotchas
+
+- Page branching APIs may be unavailable (`create_branch` / `list_branches` can 404). Substitute `create_page` with `duplicateOf` to clone a page as an experiment.
+- For reversible enhancements, layer the new thing over a static fallback rather than replacing it.
+- Figma component instances often carry repeated default labels. Confirm intended labels with the user.
+- Before saying a capability "can't" be done, test the relevant MCP tool path. If you cannot test, say it is untested and be precise about whether the limitation is Webflow itself, the MCP API, or the current tool surface.
+- Avoid broad tag/global style tests on real pages. If testing a risky capability, use an isolated duplicate page or disposable element and revert immediately.
+- After WHTML insertion, verify that expected classes survived and resolve to existing Webflow styles. Missing styles can leave rendered content unstyled even when the DOM exists.
+
+## Done Criteria
+
+- Do not call the build done until rendered output is visually checked with Designer Bridge, preview, or explicit user confirmation.
+- If visual verification is blocked, report exactly what is unverified and ask the user to check it.
+
+## Publish
+
+- Do not publish by default.
+- If the user wants a review link, publish to `.webflow.io` before any custom domain.
+- You cannot fetch `*.webflow.io` from the agent because it is robots-blocked. Ask the user to confirm:
+  - embed behavior
+  - custom code
+  - blur/backdrop effects
+  - WebGL/canvas
+  - animation
+  - mobile/responsive widths
+- Never claim those behaviors are verified from your side.


### PR DESCRIPTION
Re-opens #31, which was merged by accident and reverted in #35. Same changes, reapplied via `git revert` of the revert commit so the diff shows cleanly against current `main`. Not merging yet — holding for a later date.