### PR TITLE
docs(skills): migrate 5 skills to Webflow MCP 2.0.1 tool names

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Production-ready agent skills for Webflow - CMS management, site auditing, Designer tools, Code Components, CLI workflows, and safe publishing",
   "author": {
     "name": "Webflow",

--- a/plugins/webflow-skills/.claude-plugin/plugin.json
+++ b/plugins/webflow-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "skills": "./skills/"
 }

--- a/plugins/webflow-skills/.codex-plugin/plugin.json
+++ b/plugins/webflow-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes.",
   "author": {
     "name": "Webflow",

--- a/plugins/webflow-skills/skills/accessibility-audit/SKILL.md
+++ b/plugins/webflow-skills/skills/accessibility-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webflow-mcp:accessibility-audit
-description: Run comprehensive accessibility audit (WCAG 2.1) on Webflow pages - checks buttons, forms, links, focus states, headings, keyboard navigation, and generates detailed reports with fixes. Designer connection only needed to switch pages; element analysis and fixes run without it. Excludes image alt text (covered by asset-audit skill).
+description: Run comprehensive accessibility audit (WCAG 2.1) on Webflow pages - checks buttons, forms, links, focus states, headings, keyboard navigation, and generates detailed reports with fixes. Runs entirely headlessly against a page ID — no Designer connection required. Excludes image alt text (covered by asset-audit skill).
 mcp-version: 2.0.1
 ---
 
@@ -14,14 +14,13 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
 - Use Webflow MCP's `webflow_guide_tool` to get best practices before starting
 - Use Webflow MCP's `data_sites_tool` with action `list_sites` to identify available sites
 - Use Webflow MCP's `data_sites_tool` with action `get_site` to retrieve site details
-- Use Webflow MCP's `data_pages_tool` with action `list_pages` to get all pages
-- Use Webflow MCP's `designer_tool` with action `switch_page` to navigate to the page being audited
-- Use Webflow MCP's `data_element_tool` with action `get_all_elements` to get detailed element information
+- Use Webflow MCP's `data_pages_tool` with action `list_pages` to get all pages and their page IDs
+- Use Webflow MCP's `data_element_tool` with action `get_all_elements` (passing the page ID directly) to get detailed element information
 - Use Webflow MCP's `data_element_tool` with action `set_attributes` to fix accessibility issues
 - Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection only required to switch pages** - element extraction and attribute fixes (`data_element_tool`) run without a Designer session; only `designer_tool`'s `switch_page` action needs Designer open and connected
+- **No Designer connection is required.** `data_element_tool` operates headlessly on any page ID from `list_pages` — there's no need to switch the Designer canvas to the page being audited.
 
 ## Instructions
 
@@ -37,21 +36,17 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
    - Specific categories (forms, buttons, navigation, etc.)
 
 ### Phase 2: Element Extraction & Analysis
-4. **Ensure Designer is connected**: Before switching pages, verify Webflow Designer is open and connected
-   - If not connected, instruct user to open Designer and connect
-   - This is only required for the page-switch step below; element extraction and fixes don't need it
-5. **Switch to target page**: Use `designer_tool` with action `switch_page` to navigate to the page being audited
-6. **Extract all elements**: Use `data_element_tool` with action `get_all_elements` for detailed analysis
+4. **Extract all elements**: Use `data_element_tool` with action `get_all_elements`, passing the target page's ID from Phase 1, for detailed analysis — no Designer connection needed
    - Set `include_style_properties: true` to check focus styles
    - Set `include_all_breakpoint_styles: false` to minimize data
-7. **Parse element data**: Identify interactive and content elements:
+5. **Parse element data**: Identify interactive and content elements:
    - Buttons (Button, LinkBlock with button role)
    - Links (TextLink, Link, LinkBlock)
    - Form inputs (Input, Select, Textarea)
    - Headings (Heading elements with levels)
    - Interactive divs/spans (check for onClick or interactive roles)
    - Images (Image elements) - **SKIP for this audit**
-8. **Extract attributes for each element**:
+6. **Extract attributes for each element**:
    - ARIA attributes (aria-label, aria-describedby, role, tabIndex)
    - DOM attributes (id, domId, href, type, placeholder)
    - Text content
@@ -61,89 +56,89 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
 ### Phase 3: Accessibility Checks
 
 #### Critical Issues (Must Fix - WCAG Level A)
-9. **Icon-only buttons without labels** (WCAG 4.1.2)
+7. **Icon-only buttons without labels** (WCAG 4.1.2)
    - Find: Button elements with no text content
    - Check: Missing `aria-label` or `aria-labelledby`
    - Impact: Screen readers cannot identify button purpose
    - Fix: Add `aria-label` attribute with descriptive text
 
-10. **Form inputs without labels** (WCAG 1.3.1)
+8. **Form inputs without labels** (WCAG 1.3.1)
     - Find: Input, Select, Textarea elements
     - Check: Missing associated label or `aria-label`
     - Impact: Users don't know what input is for
     - Fix: Add `aria-label` or associate with `<label>` using `id`
 
-11. **Non-semantic click handlers** (WCAG 2.1.1)
+9. **Non-semantic click handlers** (WCAG 2.1.1)
     - Find: Div or Span elements (identified by element type)
     - Check: Interactive behavior without proper role/keyboard support
     - Impact: Not keyboard accessible, screen readers miss interactivity
     - Fix: Add `role="button"`, `tabIndex="0"`, suggest using real `<button>`
 
-12. **Links without destination** (WCAG 2.1.1)
+10. **Links without destination** (WCAG 2.1.1)
     - Find: Link elements with no `href` attribute
     - Check: Links that only use onClick without href
     - Impact: Not keyboard accessible, breaks browser features
     - Fix: Add proper `href` or convert to button
 
 #### Serious Issues (Should Fix - WCAG Level AA)
-13. **Focus outline removed without replacement** (WCAG 2.4.7)
+11. **Focus outline removed without replacement** (WCAG 2.4.7)
     - Find: Elements with `outline: none` style
     - Check: No visible alternative focus indicator
     - Impact: Keyboard users can't see focus
     - Fix: Add visible focus style (border, box-shadow, background change)
 
-14. **Missing keyboard handlers** (WCAG 2.1.1)
+12. **Missing keyboard handlers** (WCAG 2.1.1)
     - Find: Elements with onClick handlers
     - Check: Missing onKeyDown for Enter/Space keys
     - Impact: Not usable with keyboard alone
     - Fix: Add keyboard event handlers
 
-15. **Touch target too small** (WCAG 2.5.5)
+13. **Touch target too small** (WCAG 2.5.5)
     - Find: Clickable elements (buttons, links)
     - Check: Width or height < 44px
     - Impact: Hard to tap on mobile devices
     - Fix: Increase padding or min-width/min-height to 44px
 
 #### Moderate Issues (Consider Fixing)
-16. **Heading hierarchy problems** (WCAG 1.3.1)
+14. **Heading hierarchy problems** (WCAG 1.3.1)
     - Find: Heading elements (h1-h6)
     - Check: Skipped levels (h1 → h3, skipping h2)
     - Impact: Confusing document structure
     - Fix: Use proper sequential heading levels
 
-17. **Positive tabIndex** (WCAG 2.4.3)
+15. **Positive tabIndex** (WCAG 2.4.3)
     - Find: Elements with tabIndex > 0
     - Check: Disrupts natural tab order
     - Impact: Confusing keyboard navigation
     - Fix: Use tabIndex="0" or "-1" only, let natural DOM order work
 
-18. **Role without required attributes** (WCAG 4.1.2)
+16. **Role without required attributes** (WCAG 4.1.2)
     - Find: Elements with ARIA roles
     - Check: Missing required ARIA attributes (e.g., role="button" without tabIndex)
     - Impact: Incomplete accessibility semantics
     - Fix: Add required attributes for role
 
 ### Phase 4: Issue Categorization & Scoring
-19. **Categorize all findings**:
+17. **Categorize all findings**:
     - Critical: Must fix (blocks access)
     - Serious: Should fix (significantly impacts usability)
     - Moderate: Consider fixing (improves experience)
 
-20. **Calculate accessibility score** (0-100):
+18. **Calculate accessibility score** (0-100):
     - Start at 100
     - Critical issue: -10 points each
     - Serious issue: -5 points each
     - Moderate issue: -2 points each
     - Minimum score: 0
 
-21. **Generate severity summary**:
+19. **Generate severity summary**:
     - Total issues found
     - Breakdown by severity
     - Most common issue types
     - Pages/sections most affected
 
 ### Phase 5: Report Generation
-22. **Create detailed report** with specific format:
+20. **Create detailed report** with specific format:
     ```
     ═══════════════════════════════════════════════════
     ACCESSIBILITY AUDIT: [Page Name]
@@ -200,15 +195,15 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
     ═══════════════════════════════════════════════════
     ```
 
-23. **Provide actionable insights**:
+21. **Provide actionable insights**:
     - Prioritized fix list (critical first)
     - Quick wins (easy fixes with big impact)
     - Design pattern recommendations
     - Resources for learning more
 
 ### Phase 6: Fix Suggestions & Approval (Optional)
-24. **Offer to fix issues automatically**: Fixes don't require Designer, so offer auto-fixes directly
-25. **Show preview of fixes**:
+22. **Offer to fix issues automatically**: Fixes don't require Designer, so offer auto-fixes directly
+23. **Show preview of fixes**:
     ```
     Which issues would you like to fix?
 
@@ -230,23 +225,23 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
     Type numbers to skip (e.g., "3"), "all" for all, "none" to cancel
     ```
 
-26. **Apply approved fixes**: Use `data_element_tool` with action `set_attributes`
+24. **Apply approved fixes**: Use `data_element_tool` with action `set_attributes`
     - Process in batches
     - Show progress for large fix sets
     - Report success/failure for each
 
-27. **Generate post-fix report**:
+25. **Generate post-fix report**:
     - Issues fixed: X
     - Issues remaining: Y
     - New accessibility score: XX/100 (improved from YY/100)
 
 ### Phase 7: Export & Resources (Optional)
-28. **Offer export formats**:
+26. **Offer export formats**:
     - Markdown (readable documentation)
     - JSON (machine-readable for tracking)
     - CSV (spreadsheet for team review)
 
-29. **Provide resources**:
+27. **Provide resources**:
     - WCAG 2.1 quick reference links
     - Webflow accessibility best practices
     - Recommended testing tools (browser extensions, screen readers)
@@ -628,7 +623,6 @@ Would you like me to:
 
 ### Error Handling
 - If page cannot be accessed, explain clearly
-- If Designer not connected when switching pages, instruct user to open and connect it
 - If element cannot be modified, suggest manual fix
 - Separate automated fixes from manual review items
 

--- a/plugins/webflow-skills/skills/accessibility-audit/SKILL.md
+++ b/plugins/webflow-skills/skills/accessibility-audit/SKILL.md
@@ -17,10 +17,10 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
 - Use Webflow MCP's `data_pages_tool` with action `list_pages` to get all pages and their page IDs
 - Use Webflow MCP's `data_element_tool` with action `get_all_elements` (passing the page ID directly) to get detailed element information
 - Use Webflow MCP's `data_element_tool` with action `set_attributes` to fix accessibility issues
-- Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements
+- Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements — this is a Designer tool and requires a Designer connection if used
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **No Designer connection is required.** `data_element_tool` operates headlessly on any page ID from `list_pages` — there's no need to switch the Designer canvas to the page being audited.
+- **No Designer connection is required for the audit or fixes.** `data_element_tool` operates headlessly on any page ID from `list_pages`. Designer is only needed if you choose to use `element_snapshot_tool` for optional visual previews.
 
 ## Instructions
 

--- a/plugins/webflow-skills/skills/accessibility-audit/SKILL.md
+++ b/plugins/webflow-skills/skills/accessibility-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: webflow-mcp:accessibility-audit
-description: Run comprehensive accessibility audit (WCAG 2.1) on Webflow pages - checks buttons, forms, links, focus states, headings, keyboard navigation, and generates detailed reports with fixes. Requires Webflow Designer connection. Excludes image alt text (covered by asset-audit skill).
+description: Run comprehensive accessibility audit (WCAG 2.1) on Webflow pages - checks buttons, forms, links, focus states, headings, keyboard navigation, and generates detailed reports with fixes. Designer connection only needed to switch pages; element analysis and fixes run without it. Excludes image alt text (covered by asset-audit skill).
+mcp-version: 2.0.1
 ---
 
 # Accessibility Audit
@@ -14,12 +15,13 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
 - Use Webflow MCP's `data_sites_tool` with action `list_sites` to identify available sites
 - Use Webflow MCP's `data_sites_tool` with action `get_site` to retrieve site details
 - Use Webflow MCP's `data_pages_tool` with action `list_pages` to get all pages
-- Use Webflow MCP's `element_tool` with action `get_all_elements` to get detailed element information (requires Designer)
-- Use Webflow MCP's `element_tool` with action `add_or_update_attribute` to fix accessibility issues (requires Designer)
+- Use Webflow MCP's `designer_tool` with action `switch_page` to navigate to the page being audited
+- Use Webflow MCP's `data_element_tool` with action `get_all_elements` to get detailed element information
+- Use Webflow MCP's `data_element_tool` with action `set_attributes` to fix accessibility issues
 - Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection required** - This skill needs Designer to access element attributes and styles
+- **Designer connection only required to switch pages** - element extraction and attribute fixes (`data_element_tool`) run without a Designer session; only `designer_tool`'s `switch_page` action needs Designer open and connected
 
 ## Instructions
 
@@ -35,11 +37,11 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
    - Specific categories (forms, buttons, navigation, etc.)
 
 ### Phase 2: Element Extraction & Analysis
-4. **Ensure Designer is connected**: Before proceeding, verify Webflow Designer is open and connected
+4. **Ensure Designer is connected**: Before switching pages, verify Webflow Designer is open and connected
    - If not connected, instruct user to open Designer and connect
-   - This is required to access element attributes and styles
-5. **Switch to target page**: Use `de_page_tool` with action `switch_page` to navigate to the page being audited
-6. **Extract all elements**: Use `element_tool` with action `get_all_elements` for detailed analysis
+   - This is only required for the page-switch step below; element extraction and fixes don't need it
+5. **Switch to target page**: Use `designer_tool` with action `switch_page` to navigate to the page being audited
+6. **Extract all elements**: Use `data_element_tool` with action `get_all_elements` for detailed analysis
    - Set `include_style_properties: true` to check focus styles
    - Set `include_all_breakpoint_styles: false` to minimize data
 7. **Parse element data**: Identify interactive and content elements:
@@ -205,7 +207,7 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
     - Resources for learning more
 
 ### Phase 6: Fix Suggestions & Approval (Optional)
-24. **Offer to fix issues automatically**: Designer is already connected, so offer auto-fixes
+24. **Offer to fix issues automatically**: Fixes don't require Designer, so offer auto-fixes directly
 25. **Show preview of fixes**:
     ```
     Which issues would you like to fix?
@@ -228,7 +230,7 @@ Comprehensive WCAG 2.1 accessibility audit for Webflow pages with detailed issue
     Type numbers to skip (e.g., "3"), "all" for all, "none" to cancel
     ```
 
-26. **Apply approved fixes**: Use `element_tool` with action `add_or_update_attribute`
+26. **Apply approved fixes**: Use `data_element_tool` with action `set_attributes`
     - Process in batches
     - Show progress for large fix sets
     - Report success/failure for each
@@ -433,7 +435,7 @@ Quick Wins (Easy + High Impact):
 3. Test with keyboard navigation (Tab, Enter, Space keys)
 4. Consider testing with screen reader (NVDA/JAWS/VoiceOver)
 
-Would you like me to help fix these issues? (requires Designer connection)
+Would you like me to help fix these issues?
 ```
 
 ### Example 2: Multi-Page Audit
@@ -546,7 +548,7 @@ RECOMMENDATIONS
 Would you like:
 1. Detailed report for specific page
 2. Export findings to file (Markdown/JSON/CSV)
-3. Help fixing site-wide issues (requires Designer)
+3. Help fixing site-wide issues
 ```
 
 ### Example 3: Critical Issues Only
@@ -606,7 +608,7 @@ Found: 4 critical issues
 
 Would you like me to:
 1. Run full audit (includes serious and moderate issues)
-2. Fix these 4 critical issues now (requires Designer)
+2. Fix these 4 critical issues now
 3. Export this report (Markdown/JSON/CSV)
 ```
 
@@ -626,7 +628,7 @@ Would you like me to:
 
 ### Error Handling
 - If page cannot be accessed, explain clearly
-- If Designer not connected, list limitations
+- If Designer not connected when switching pages, instruct user to open and connect it
 - If element cannot be modified, suggest manual fix
 - Separate automated fixes from manual review items
 

--- a/plugins/webflow-skills/skills/asset-audit/SKILL.md
+++ b/plugins/webflow-skills/skills/asset-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: webflow-mcp:asset-audit
 description: Analyze assets on a Webflow site for SEO optimization. Identifies assets missing alt text and assets with non-SEO-friendly names, then generates and applies improvements.
+mcp-version: 2.0.1
 ---
 
 # Asset Audit
@@ -10,8 +11,8 @@ Analyze assets on a Webflow site for SEO optimization.
 ## Important Note
 
 **ALWAYS use Webflow MCP tools for all operations:**
-- Use Webflow MCP's `asset_tool` for fetching and updating assets
-- Use Webflow MCP's `get_image_preview` for analyzing image content
+- Use Webflow MCP's `data_assets_tool` for fetching and updating assets
+- Use Webflow MCP's `get_asset_preview` (with the asset's `asset_id`) for analyzing image content
 - Use Webflow MCP's `data_sites_tool` with action `list_sites` for listing available sites
 - Use Webflow MCP's `webflow_guide_tool` to get best practices before starting
 - DO NOT use any other tools or methods for Webflow operations
@@ -21,7 +22,7 @@ Analyze assets on a Webflow site for SEO optimization.
 
 ### Phase 1: Site Selection & Asset Discovery
 1. **Get site**: Identify the target site. If user does not provide site ID, ask for it.
-2. **Fetch all assets**: Use Webflow MCP's `asset_tool` to get all assets from the site
+2. **Fetch all assets**: Use Webflow MCP's `data_assets_tool` to get all assets from the site (each asset record includes its `asset_id`, needed for previews)
    - For sites with 50+ assets, process in batches of 20
    - Show progress: "Processing assets 1-20 of 150..."
 3. **Detect patterns**: Analyze asset naming for common patterns:
@@ -50,8 +51,8 @@ Analyze assets on a Webflow site for SEO optimization.
    - Apply naming pattern/template
 
 ### Phase 3: Analysis & Suggestion Generation
-7. **Analyze assets**: Use Webflow MCP's `get_image_preview` tool to analyze the assets that need updates
-   - **Error handling**: If Webflow MCP's `get_image_preview` fails, use fallback:
+7. **Analyze assets**: Use Webflow MCP's `get_asset_preview` tool, passing each asset's `asset_id` (from Phase 1), to analyze the assets that need updates
+   - **Error handling**: If Webflow MCP's `get_asset_preview` fails, use fallback:
      - Extract description from existing filename
      - Use generic placeholder with warning
      - Continue with other assets
@@ -94,7 +95,7 @@ Analyze assets on a Webflow site for SEO optimization.
     - Original alt text
     - Timestamp
     - Assets modified
-13. **Apply updates**: Use Webflow MCP's `asset_tool` to update approved assets only
+13. **Apply updates**: Use Webflow MCP's `data_assets_tool` to update approved assets only
     - Show progress for batch updates
     - Handle partial failures gracefully
     - Report successes and failures separately
@@ -316,7 +317,7 @@ Type "undo" to revert these 2 changes
 - Sites with 50+ assets: Process in batches of 20
 - Show progress: "Processing batch 1 of 5 (assets 1-20)..."
 - Allow user to process specific batches
-- Timeout protection: If Webflow MCP's `get_image_preview` takes > 30s, skip to next batch
+- Timeout protection: If Webflow MCP's `get_asset_preview` takes > 30s, skip to next batch
 
 **Pattern Detection:**
 Detect and report these patterns:
@@ -327,7 +328,7 @@ Detect and report these patterns:
 - Suggest bulk rename when 3+ assets match a pattern
 
 **Error Handling:**
-- If Webflow MCP's `get_image_preview` fails:
+- If Webflow MCP's `get_asset_preview` fails:
   1. Log the error (don't show to user)
   2. Use fallback: Extract description from filename
   3. Mark with ⚠️ warning: "Generated from filename (image preview failed)"
@@ -393,7 +394,7 @@ Before any update, store in memory:
 
 ### General Best Practices
 
-- Always use Webflow MCP's `get_image_preview` to understand image content
+- Always use Webflow MCP's `get_asset_preview` (with `asset_id`, not a URL) to understand image content
 - Generate specific, descriptive suggestions (not generic)
 - Validate all suggestions before presenting to user
 - Handle partial operations gracefully

--- a/plugins/webflow-skills/skills/designer-tools/SKILL.md
+++ b/plugins/webflow-skills/skills/designer-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webflow-mcp:designer-tools
-description: Build and manage pages, elements, components, and styles in Webflow Designer. Use when adding sections, creating layouts, building elements, inspecting or updating components, viewing what's inside a component, restructuring pages, creating new pages, previewing page structure, styling elements, or managing component properties. Most operations run without a Designer connection; only page/element selection and component-instance edits require Webflow Designer to be open and connected.
+description: Build and manage pages, elements, components, and styles in Webflow Designer. Use when adding sections, creating layouts, building elements, inspecting or updating components, viewing what's inside a component, restructuring pages, creating new pages, previewing page structure, styling elements, or managing component properties. Nearly everything runs headlessly against an explicit page ID — no Designer connection needed. Designer is only required to read/switch the page currently open on canvas, interactively select an element, create page folders, or open a component's canvas view.
 mcp-version: 2.0.1
 ---
 
@@ -13,64 +13,64 @@ Build, inspect, and manage page elements and components in the Webflow Designer.
 **ALWAYS use Webflow MCP tools for all operations:**
 - Use Webflow MCP's `webflow_guide_tool` to get best practices **before any other tool call**
 - Use Webflow MCP's `data_sites_tool` with action `list_sites` to identify the target site
-- Use Webflow MCP's `designer_tool` to get the current page or switch pages
-- Use Webflow MCP's `data_pages_tool` to create pages or folders
-- Use Webflow MCP's `data_element_tool` with action `get_all_elements` to retrieve page elements
-- Use Webflow MCP's `designer_tool` with action `select_element` to select a specific element
-- Use Webflow MCP's `data_element_tool` with action `set_attributes` to update element attributes
-- Use Webflow MCP's `data_element_builder` to create new elements
+- Use Webflow MCP's `data_pages_tool` with action `list_pages` to find the target page by name or slug — headless, works against any page
+- Use Webflow MCP's `data_pages_tool` with action `create_page` to create new pages — headless
+- Use Webflow MCP's `data_element_tool` with action `get_all_elements` or `query_elements` to retrieve or filter page elements — headless, pass the page's ID directly
+- Use Webflow MCP's `data_element_builder` to create new elements — headless, pass the page's ID and a parent element ID
+- Use Webflow MCP's `data_element_tool` with action `set_attributes`, `set_text`, `set_style`, or `set_link` to modify elements — headless
 - Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements before and after changes
-- Use Webflow MCP's `data_style_tool` to create and update styles on elements
+- Use Webflow MCP's `data_style_tool` to create and update styles on elements — headless
 - Use Webflow MCP's `webflow_guide_tool` to check supported style properties
-- Use Webflow MCP's `data_component_tool` with action `list_components` to list all site components
-- Use Webflow MCP's `data_component_tool` with action `get_component_content` to inspect a component
-- Use Webflow MCP's `data_component_tool` with action `update_component_content` to update component content
-- Use Webflow MCP's `data_component_tool` with action `get_component_properties` to get component properties
-- Use Webflow MCP's `data_component_tool` with action `update_component_properties` to update component properties
-- Use Webflow MCP's `designer_tool` to manage component instances in the Designer
+- Use Webflow MCP's `data_component_tool` with action `get_all_components` or `query_components` to list site components — headless
+- Use Webflow MCP's `data_component_tool` with action `get_component` to inspect a component's metadata — headless
+- Use Webflow MCP's `data_element_tool` scoped with `scope_component_id` to inspect or edit a component's internal elements (its "content") — headless
+- Use Webflow MCP's `data_component_props_tool` to manage prop definitions and set prop values on component instances — headless
+- Use Webflow MCP's `data_component_variants_tool` to manage variants and per-variant style overrides — headless
+- Use Webflow MCP's `data_component_tool` with action `insert_component_instance` or `unlink_component_instance` to manage component instances on a page — headless, not Designer-gated
+- Use Webflow MCP's `designer_tool` only for actions that need a live canvas: `get_current_page`/`switch_page` (what's open in Designer right now), `select_element`/`get_selected_element` (interactive canvas selection), `create_page_folder` (page folders are Designer-only, unlike page creation itself), and `open_component_view` (viewing a component's canvas)
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection required only for `designer_tool` actions** — getting/switching the current page, selecting elements, and editing component instances all need Webflow Designer open and connected. Everything else (building elements, styling, updating shared component content) works without it.
+- **Designer connection is only required for `designer_tool` actions.** Everything else — building, styling, inspecting, and updating elements, components, props, and variants — runs headlessly against an explicit page ID from `data_pages_tool`'s `list_pages`.
 
 ## Instructions
 
 ### Phase 1: Discovery
 1. **Call `webflow_guide_tool` first** — always the first MCP tool call in any workflow
 2. **Get the site**: Use `data_sites_tool` with action `list_sites` to identify the target site. If only one site exists, use it automatically.
-3. **Get current page**: Use `designer_tool` to identify which page is active in the Designer
-4. **If user specifies a different page**: Use `designer_tool` to switch to it before proceeding
-4. **Identify the task type**:
+3. **Get the target page**: Use `data_pages_tool` with action `list_pages` to find the page by name or slug — no Designer connection needed. If the user is actively working in an open Designer session and wants "the page I have open," use `designer_tool` with action `get_current_page` instead.
+4. **If user specifies a different page**: Just use that page's ID directly in later calls — no page "switch" is needed for headless operations. Only use `designer_tool` with action `switch_page` if the user wants the Designer canvas itself to navigate there.
+5. **Identify the task type**:
    - **Inspect**: List elements, view structure, preview → go to Phase 2
    - **Build/Modify/Delete**: Add, update, restructure, remove → go to Phase 3
    - **Components**: List, inspect, update → go to Phase 2 or Phase 3 depending on read vs write
 
 ### Phase 2: Inspection (read-only operations)
-5. **List page elements**: Use `designer_tool` then `data_element_tool` with `get_all_elements` to retrieve page structure. Present a summary of sections, elements, and nesting.
-6. **Preview elements**: Use `element_snapshot_tool` to get visual previews of specific sections
-7. **List components**: Use `data_component_tool` with action `list_components` to list all site components
-8. **Inspect a component**: Use `data_component_tool` with action `get_component_content` or `designer_tool` for Designer instances
+6. **List page elements**: Use `data_element_tool` with `get_all_elements` (or `query_elements` to filter by type/text/attribute) to retrieve page structure, passing the page ID from Phase 1. Present a summary of sections, elements, and nesting.
+7. **Preview elements**: Use `element_snapshot_tool` to get visual previews of specific sections
+8. **List components**: Use `data_component_tool` with action `get_all_components` or `query_components` to list all site components
+9. **Inspect a component**: Use `data_component_tool` with action `get_component` for metadata (props, variants), or `data_element_tool` with `scope_component_id` set to the component's ID to inspect its internal elements
 
 ### Phase 3: Planning (before any mutation)
 Before creating, updating, or deleting anything:
-9. **Snapshot current state**: Use `element_snapshot_tool` to capture the area being changed
-10. **Present the plan**: Describe exactly what will be created, modified, or deleted
-11. **Request explicit confirmation**: Ask the user before proceeding:
+10. **Snapshot current state**: Use `element_snapshot_tool` to capture the area being changed
+11. **Present the plan**: Describe exactly what will be created, modified, or deleted
+12. **Request explicit confirmation**: Ask the user before proceeding:
     - "Would you like me to proceed with these changes?"
     - "Shall I go ahead and create this?"
     - "Do you want me to apply these changes?"
     - "Before I make changes, here's what I'll do: [plan]. Confirm to proceed."
-12. **For destructive operations** (delete, restructure): Require "confirm" or "delete", warn about child elements that will also be affected
+13. **For destructive operations** (delete, restructure): Require "confirm" or "delete", warn about child elements that will also be affected
 
 ### Phase 4: Execution (after confirmation only)
-13. **Build elements**: Use `data_element_builder` to create new elements (max 3 levels deep). For deeper structures, build in multiple passes.
-14. **Style elements**: Use `data_style_tool` to apply or update styles on created or existing elements
-15. **Modify elements**: Use `data_element_tool` with `set_attributes` to update attributes, text, or links
-16. **Update components**: Use `data_component_tool` with `update_component_content` or `update_component_properties`. Use `designer_tool` for Designer-level instance changes.
-17. **Create pages**: Use `data_pages_tool` to create new pages or folders
+14. **Build elements**: Use `data_element_builder` to create new elements (max 3 levels deep), passing the page ID and the parent element ID. For deeper structures, build in multiple passes.
+15. **Style elements**: Use `data_style_tool` to apply or update styles on created or existing elements
+16. **Modify elements**: Use `data_element_tool` with `set_attributes`, `set_text`, `set_style`, or `set_link` to update attributes, text, or links
+17. **Update components**: Use `data_element_tool` (scoped with `scope_component_id`) to edit a component's internal elements; `data_component_props_tool` to change prop definitions or instance prop values; `data_component_variants_tool` to manage variants; `data_component_tool` with `insert_component_instance`/`unlink_component_instance` to add or unlink instances on a page
+18. **Create pages**: Use `data_pages_tool` with action `create_page`. To create a page **folder**, use `designer_tool` with action `create_page_folder` — this specific action requires a Designer connection
 
 ### Phase 5: Verification
-18. **Snapshot the result**: Use `element_snapshot_tool` to capture the new state
-19. **Report what changed**: Summarize the changes made
+19. **Snapshot the result**: Use `element_snapshot_tool` to capture the new state
+20. **Report what changed**: Summarize the changes made
 
 ## Examples
 
@@ -80,8 +80,8 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `designer_tool` to confirm current page is homepage (switch if needed)
-4. Call `data_element_tool` with `get_all_elements` to retrieve page structure
+3. Call `data_pages_tool` with `list_pages` to find the homepage's page ID
+4. Call `data_element_tool` with `get_all_elements` (using that page ID) to retrieve page structure
 5. Present organized summary of sections, elements, and nesting
 
 ### Example 2: Build a hero section
@@ -90,12 +90,12 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `designer_tool` to get current page
+3. Call `data_pages_tool` with `list_pages` to find the target page's ID
 4. Call `element_snapshot_tool` to capture current state
-4. Present plan: "I'll create a Section with a Heading and Button. Would you like me to proceed?"
-5. After confirmation: call `data_element_builder` with nested structure
-6. Call `data_style_tool` to apply styles (padding, background, typography)
-7. Call `element_snapshot_tool` to show the result
+5. Present plan: "I'll create a Section with a Heading and Button. Would you like me to proceed?"
+6. After confirmation: call `data_element_builder` with nested structure
+7. Call `data_style_tool` to apply styles (padding, background, typography)
+8. Call `element_snapshot_tool` to show the result
 
 ### Example 3: Update a component
 
@@ -103,11 +103,11 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `data_component_tool` with `list_components` to find the footer
-3. Call `data_component_tool` with `get_component_content` to inspect it
-4. Present: "I'll update the copyright text from '2025' to '2026'. Would you like me to proceed?"
-5. After confirmation: call `data_component_tool` with `update_component_content`
-6. Report the change
+3. Call `data_component_tool` with `query_components` to find the footer component
+4. Call `data_element_tool` (scoped with `scope_component_id`) to inspect its internal elements and find the copyright text element
+5. Present: "I'll update the copyright text from '2025' to '2026'. Would you like me to proceed?"
+6. After confirmation: call `data_element_tool` with `set_text` (scoped with `scope_component_id`)
+7. Report the change
 
 ### Example 4: Restructure a section
 
@@ -115,12 +115,12 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `designer_tool` to get current page
-3. Call `element_snapshot_tool` to capture current hero section
-4. Call `data_element_tool` to inspect current structure
-5. Present restructuring plan with before/after description
-6. After confirmation: apply changes using `data_element_tool` and/or `data_element_builder`
-7. Call `element_snapshot_tool` to show the result
+3. Call `data_pages_tool` with `list_pages` to find the target page's ID
+4. Call `element_snapshot_tool` to capture current hero section
+5. Call `data_element_tool` with `query_elements` to inspect current structure
+6. Present restructuring plan with before/after description
+7. After confirmation: apply changes using `data_element_tool` (`move_element`, `set_style`, etc.) and/or `data_element_builder`
+8. Call `element_snapshot_tool` to show the result
 
 ### Example 5: Create a two-column layout
 
@@ -128,22 +128,22 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `designer_tool` to get current page
-3. Call `element_snapshot_tool` to capture current state
-4. Present plan: "I'll create a Grid with two columns — text block on left, image on right. Would you like me to proceed?"
-5. After confirmation: call `data_element_builder` with grid structure
-6. Call `data_style_tool` to set grid layout properties
-7. Call `element_snapshot_tool` to show the result
+3. Call `data_pages_tool` with `list_pages` to find the target page's ID
+4. Call `element_snapshot_tool` to capture current state
+5. Present plan: "I'll create a Grid with two columns — text block on left, image on right. Would you like me to proceed?"
+6. After confirmation: call `data_element_builder` with grid structure
+7. Call `data_style_tool` to set grid layout properties
+8. Call `element_snapshot_tool` to show the result
 
 ## Guidelines
 
 - **`webflow_guide_tool` always first** — before any other MCP tool in every workflow
 - **Snapshot before and after** — use `element_snapshot_tool` before mutations and after to show results
 - **Never silently mutate** — every write operation requires explicit user confirmation
-- **`designer_tool` before `data_element_tool`** — always confirm/switch page before inspecting elements
+- **Headless by default** — get the page ID once via `data_pages_tool`'s `list_pages`, then pass it directly to `data_element_tool`, `data_element_builder`, and `data_style_tool`. Reach for `designer_tool` only when the task specifically needs the live canvas (current-page detection, interactive selection, page folders, component canvas view).
 - **Batch changes need itemized preview** — if modifying multiple elements, list each change
 - Prefer Webflow's native layout tools (Grid, Flexbox) over manual positioning
-- Components shared across pages should be updated via `data_component_tool` (changes propagate)
-- Component instances on a specific page use `designer_tool`
+- Components shared across pages should be updated via `data_element_tool` scoped to the component (changes propagate to all instances)
+- Component instance management (`insert_component_instance`, `unlink_component_instance`) is headless via `data_component_tool` — not Designer-gated
 - `data_element_builder` supports max 3 levels per call — build deeper structures in stages
 - Check `webflow_guide_tool` for supported style properties when unsure

--- a/plugins/webflow-skills/skills/designer-tools/SKILL.md
+++ b/plugins/webflow-skills/skills/designer-tools/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: webflow-mcp:designer-tools
-description: Build and manage pages, elements, components, and styles in Webflow Designer. Use when adding sections, creating layouts, building elements, inspecting or updating components, viewing what's inside a component, restructuring pages, creating new pages, previewing page structure, styling elements, or managing component properties. Requires Webflow Designer connection.
+description: Build and manage pages, elements, components, and styles in Webflow Designer. Use when adding sections, creating layouts, building elements, inspecting or updating components, viewing what's inside a component, restructuring pages, creating new pages, previewing page structure, styling elements, or managing component properties. Most operations run without a Designer connection; only page/element selection and component-instance edits require Webflow Designer to be open and connected.
+mcp-version: 2.0.1
 ---
 
 # Page Structure
@@ -12,41 +13,42 @@ Build, inspect, and manage page elements and components in the Webflow Designer.
 **ALWAYS use Webflow MCP tools for all operations:**
 - Use Webflow MCP's `webflow_guide_tool` to get best practices **before any other tool call**
 - Use Webflow MCP's `data_sites_tool` with action `list_sites` to identify the target site
-- Use Webflow MCP's `de_page_tool` to get current page, switch pages, or create pages/folders
-- Use Webflow MCP's `element_tool` with action `get_all_elements` to retrieve page elements
-- Use Webflow MCP's `element_tool` with action `select_element` to select a specific element
-- Use Webflow MCP's `element_tool` with action `add_or_update_attribute` to update element attributes
-- Use Webflow MCP's `element_builder` to create new elements
+- Use Webflow MCP's `designer_tool` to get the current page or switch pages
+- Use Webflow MCP's `data_pages_tool` to create pages or folders
+- Use Webflow MCP's `data_element_tool` with action `get_all_elements` to retrieve page elements
+- Use Webflow MCP's `designer_tool` with action `select_element` to select a specific element
+- Use Webflow MCP's `data_element_tool` with action `set_attributes` to update element attributes
+- Use Webflow MCP's `data_element_builder` to create new elements
 - Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements before and after changes
-- Use Webflow MCP's `style_tool` to create and update styles on elements
-- Use Webflow MCP's `de_learn_more_about_styles` to check supported style properties
-- Use Webflow MCP's `data_components_tool` with action `list_components` to list all site components
-- Use Webflow MCP's `data_components_tool` with action `get_component_content` to inspect a component
-- Use Webflow MCP's `data_components_tool` with action `update_component_content` to update component content
-- Use Webflow MCP's `data_components_tool` with action `get_component_properties` to get component properties
-- Use Webflow MCP's `data_components_tool` with action `update_component_properties` to update component properties
-- Use Webflow MCP's `de_component_tool` to manage component instances in the Designer
+- Use Webflow MCP's `data_style_tool` to create and update styles on elements
+- Use Webflow MCP's `webflow_guide_tool` to check supported style properties
+- Use Webflow MCP's `data_component_tool` with action `list_components` to list all site components
+- Use Webflow MCP's `data_component_tool` with action `get_component_content` to inspect a component
+- Use Webflow MCP's `data_component_tool` with action `update_component_content` to update component content
+- Use Webflow MCP's `data_component_tool` with action `get_component_properties` to get component properties
+- Use Webflow MCP's `data_component_tool` with action `update_component_properties` to update component properties
+- Use Webflow MCP's `designer_tool` to manage component instances in the Designer
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection required** — user must have Webflow Designer open and connected
+- **Designer connection required only for `designer_tool` actions** — getting/switching the current page, selecting elements, and editing component instances all need Webflow Designer open and connected. Everything else (building elements, styling, updating shared component content) works without it.
 
 ## Instructions
 
 ### Phase 1: Discovery
 1. **Call `webflow_guide_tool` first** — always the first MCP tool call in any workflow
 2. **Get the site**: Use `data_sites_tool` with action `list_sites` to identify the target site. If only one site exists, use it automatically.
-3. **Get current page**: Use `de_page_tool` to identify which page is active in the Designer
-4. **If user specifies a different page**: Use `de_page_tool` to switch to it before proceeding
+3. **Get current page**: Use `designer_tool` to identify which page is active in the Designer
+4. **If user specifies a different page**: Use `designer_tool` to switch to it before proceeding
 4. **Identify the task type**:
    - **Inspect**: List elements, view structure, preview → go to Phase 2
    - **Build/Modify/Delete**: Add, update, restructure, remove → go to Phase 3
    - **Components**: List, inspect, update → go to Phase 2 or Phase 3 depending on read vs write
 
 ### Phase 2: Inspection (read-only operations)
-5. **List page elements**: Use `de_page_tool` then `element_tool` with `get_all_elements` to retrieve page structure. Present a summary of sections, elements, and nesting.
+5. **List page elements**: Use `designer_tool` then `data_element_tool` with `get_all_elements` to retrieve page structure. Present a summary of sections, elements, and nesting.
 6. **Preview elements**: Use `element_snapshot_tool` to get visual previews of specific sections
-7. **List components**: Use `data_components_tool` with action `list_components` to list all site components
-8. **Inspect a component**: Use `data_components_tool` with action `get_component_content` or `de_component_tool` for Designer instances
+7. **List components**: Use `data_component_tool` with action `list_components` to list all site components
+8. **Inspect a component**: Use `data_component_tool` with action `get_component_content` or `designer_tool` for Designer instances
 
 ### Phase 3: Planning (before any mutation)
 Before creating, updating, or deleting anything:
@@ -60,11 +62,11 @@ Before creating, updating, or deleting anything:
 12. **For destructive operations** (delete, restructure): Require "confirm" or "delete", warn about child elements that will also be affected
 
 ### Phase 4: Execution (after confirmation only)
-13. **Build elements**: Use `element_builder` to create new elements (max 3 levels deep). For deeper structures, build in multiple passes.
-14. **Style elements**: Use `style_tool` to apply or update styles on created or existing elements
-15. **Modify elements**: Use `element_tool` with `add_or_update_attribute` to update attributes, text, or links
-16. **Update components**: Use `data_components_tool` with `update_component_content` or `update_component_properties`. Use `de_component_tool` for Designer-level instance changes.
-17. **Create pages**: Use `de_page_tool` to create new pages or folders
+13. **Build elements**: Use `data_element_builder` to create new elements (max 3 levels deep). For deeper structures, build in multiple passes.
+14. **Style elements**: Use `data_style_tool` to apply or update styles on created or existing elements
+15. **Modify elements**: Use `data_element_tool` with `set_attributes` to update attributes, text, or links
+16. **Update components**: Use `data_component_tool` with `update_component_content` or `update_component_properties`. Use `designer_tool` for Designer-level instance changes.
+17. **Create pages**: Use `data_pages_tool` to create new pages or folders
 
 ### Phase 5: Verification
 18. **Snapshot the result**: Use `element_snapshot_tool` to capture the new state
@@ -78,8 +80,8 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `de_page_tool` to confirm current page is homepage (switch if needed)
-4. Call `element_tool` with `get_all_elements` to retrieve page structure
+3. Call `designer_tool` to confirm current page is homepage (switch if needed)
+4. Call `data_element_tool` with `get_all_elements` to retrieve page structure
 5. Present organized summary of sections, elements, and nesting
 
 ### Example 2: Build a hero section
@@ -88,11 +90,11 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `de_page_tool` to get current page
+3. Call `designer_tool` to get current page
 4. Call `element_snapshot_tool` to capture current state
 4. Present plan: "I'll create a Section with a Heading and Button. Would you like me to proceed?"
-5. After confirmation: call `element_builder` with nested structure
-6. Call `style_tool` to apply styles (padding, background, typography)
+5. After confirmation: call `data_element_builder` with nested structure
+6. Call `data_style_tool` to apply styles (padding, background, typography)
 7. Call `element_snapshot_tool` to show the result
 
 ### Example 3: Update a component
@@ -101,10 +103,10 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `data_components_tool` with `list_components` to find the footer
-3. Call `data_components_tool` with `get_component_content` to inspect it
+3. Call `data_component_tool` with `list_components` to find the footer
+3. Call `data_component_tool` with `get_component_content` to inspect it
 4. Present: "I'll update the copyright text from '2025' to '2026'. Would you like me to proceed?"
-5. After confirmation: call `data_components_tool` with `update_component_content`
+5. After confirmation: call `data_component_tool` with `update_component_content`
 6. Report the change
 
 ### Example 4: Restructure a section
@@ -113,11 +115,11 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `de_page_tool` to get current page
+3. Call `designer_tool` to get current page
 3. Call `element_snapshot_tool` to capture current hero section
-4. Call `element_tool` to inspect current structure
+4. Call `data_element_tool` to inspect current structure
 5. Present restructuring plan with before/after description
-6. After confirmation: apply changes using `element_tool` and/or `element_builder`
+6. After confirmation: apply changes using `data_element_tool` and/or `data_element_builder`
 7. Call `element_snapshot_tool` to show the result
 
 ### Example 5: Create a two-column layout
@@ -126,11 +128,11 @@ Before creating, updating, or deleting anything:
 
 1. Call `webflow_guide_tool` for best practices
 2. Call `data_sites_tool` with `list_sites` to identify the site
-3. Call `de_page_tool` to get current page
+3. Call `designer_tool` to get current page
 3. Call `element_snapshot_tool` to capture current state
 4. Present plan: "I'll create a Grid with two columns — text block on left, image on right. Would you like me to proceed?"
-5. After confirmation: call `element_builder` with grid structure
-6. Call `style_tool` to set grid layout properties
+5. After confirmation: call `data_element_builder` with grid structure
+6. Call `data_style_tool` to set grid layout properties
 7. Call `element_snapshot_tool` to show the result
 
 ## Guidelines
@@ -138,10 +140,10 @@ Before creating, updating, or deleting anything:
 - **`webflow_guide_tool` always first** — before any other MCP tool in every workflow
 - **Snapshot before and after** — use `element_snapshot_tool` before mutations and after to show results
 - **Never silently mutate** — every write operation requires explicit user confirmation
-- **`de_page_tool` before `element_tool`** — always confirm/switch page before inspecting elements
+- **`designer_tool` before `data_element_tool`** — always confirm/switch page before inspecting elements
 - **Batch changes need itemized preview** — if modifying multiple elements, list each change
 - Prefer Webflow's native layout tools (Grid, Flexbox) over manual positioning
-- Components shared across pages should be updated via `data_components_tool` (changes propagate)
-- Component instances on a specific page use `de_component_tool`
-- `element_builder` supports max 3 levels per call — build deeper structures in stages
-- Check `de_learn_more_about_styles` for supported style properties when unsure
+- Components shared across pages should be updated via `data_component_tool` (changes propagate)
+- Component instances on a specific page use `designer_tool`
+- `data_element_builder` supports max 3 levels per call — build deeper structures in stages
+- Check `webflow_guide_tool` for supported style properties when unsure

--- a/plugins/webflow-skills/skills/designer-tools/SKILL.md
+++ b/plugins/webflow-skills/skills/designer-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webflow-mcp:designer-tools
-description: Build and manage pages, elements, components, and styles in Webflow Designer. Use when adding sections, creating layouts, building elements, inspecting or updating components, viewing what's inside a component, restructuring pages, creating new pages, previewing page structure, styling elements, or managing component properties. Nearly everything runs headlessly against an explicit page ID — no Designer connection needed. Designer is only required to read/switch the page currently open on canvas, interactively select an element, create page folders, or open a component's canvas view.
+description: Build and manage pages, elements, components, and styles in Webflow Designer. Use when adding sections, creating layouts, building elements, inspecting or updating components, viewing what's inside a component, restructuring pages, creating new pages, previewing page structure, styling elements, or managing component properties. Building, styling, and inspecting run headlessly against an explicit page ID — no Designer connection needed. Designer is required for `designer_tool` actions (reading/switching the page open on canvas, interactively selecting an element, creating page folders, opening a component's canvas view) and for `element_snapshot_tool` visual previews.
 mcp-version: 2.0.1
 ---
 
@@ -18,7 +18,7 @@ Build, inspect, and manage page elements and components in the Webflow Designer.
 - Use Webflow MCP's `data_element_tool` with action `get_all_elements` or `query_elements` to retrieve or filter page elements — headless, pass the page's ID directly
 - Use Webflow MCP's `data_element_builder` to create new elements — headless, pass the page's ID and a parent element ID
 - Use Webflow MCP's `data_element_tool` with action `set_attributes`, `set_text`, `set_style`, or `set_link` to modify elements — headless
-- Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements before and after changes
+- Use Webflow MCP's `element_snapshot_tool` to get visual previews of elements before and after changes — this is a Designer tool and requires a Designer connection
 - Use Webflow MCP's `data_style_tool` to create and update styles on elements — headless
 - Use Webflow MCP's `webflow_guide_tool` to check supported style properties
 - Use Webflow MCP's `data_component_tool` with action `get_all_components` or `query_components` to list site components — headless
@@ -30,7 +30,7 @@ Build, inspect, and manage page elements and components in the Webflow Designer.
 - Use Webflow MCP's `designer_tool` only for actions that need a live canvas: `get_current_page`/`switch_page` (what's open in Designer right now), `select_element`/`get_selected_element` (interactive canvas selection), `create_page_folder` (page folders are Designer-only, unlike page creation itself), and `open_component_view` (viewing a component's canvas)
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection is only required for `designer_tool` actions.** Everything else — building, styling, inspecting, and updating elements, components, props, and variants — runs headlessly against an explicit page ID from `data_pages_tool`'s `list_pages`.
+- **Designer connection is required for `designer_tool` actions and for `element_snapshot_tool`.** Building, styling, inspecting, and updating elements, components, props, and variants (the `data_` tools) runs headlessly against an explicit page ID from `data_pages_tool`'s `list_pages` — but the before/after visual snapshots this skill relies on for safe mutation need Designer open and connected. If Designer isn't available, skip the snapshot steps and rely on `query_elements` output to describe changes instead.
 
 ## Instructions
 
@@ -46,13 +46,13 @@ Build, inspect, and manage page elements and components in the Webflow Designer.
 
 ### Phase 2: Inspection (read-only operations)
 6. **List page elements**: Use `data_element_tool` with `get_all_elements` (or `query_elements` to filter by type/text/attribute) to retrieve page structure, passing the page ID from Phase 1. Present a summary of sections, elements, and nesting.
-7. **Preview elements**: Use `element_snapshot_tool` to get visual previews of specific sections
+7. **Preview elements**: Use `element_snapshot_tool` to get visual previews of specific sections — requires Designer
 8. **List components**: Use `data_component_tool` with action `get_all_components` or `query_components` to list all site components
 9. **Inspect a component**: Use `data_component_tool` with action `get_component` for metadata (props, variants), or `data_element_tool` with `scope_component_id` set to the component's ID to inspect its internal elements
 
 ### Phase 3: Planning (before any mutation)
 Before creating, updating, or deleting anything:
-10. **Snapshot current state**: Use `element_snapshot_tool` to capture the area being changed
+10. **Snapshot current state**: Use `element_snapshot_tool` to capture the area being changed — requires Designer; if unavailable, describe the current state from `query_elements` output instead
 11. **Present the plan**: Describe exactly what will be created, modified, or deleted
 12. **Request explicit confirmation**: Ask the user before proceeding:
     - "Would you like me to proceed with these changes?"
@@ -69,7 +69,7 @@ Before creating, updating, or deleting anything:
 18. **Create pages**: Use `data_pages_tool` with action `create_page`. To create a page **folder**, use `designer_tool` with action `create_page_folder` — this specific action requires a Designer connection
 
 ### Phase 5: Verification
-19. **Snapshot the result**: Use `element_snapshot_tool` to capture the new state
+19. **Snapshot the result**: Use `element_snapshot_tool` to capture the new state — requires Designer; if unavailable, summarize the change from the tool response instead
 20. **Report what changed**: Summarize the changes made
 
 ## Examples
@@ -140,7 +140,8 @@ Before creating, updating, or deleting anything:
 - **`webflow_guide_tool` always first** — before any other MCP tool in every workflow
 - **Snapshot before and after** — use `element_snapshot_tool` before mutations and after to show results
 - **Never silently mutate** — every write operation requires explicit user confirmation
-- **Headless by default** — get the page ID once via `data_pages_tool`'s `list_pages`, then pass it directly to `data_element_tool`, `data_element_builder`, and `data_style_tool`. Reach for `designer_tool` only when the task specifically needs the live canvas (current-page detection, interactive selection, page folders, component canvas view).
+- **Headless for building and editing** — get the page ID once via `data_pages_tool`'s `list_pages`, then pass it directly to `data_element_tool`, `data_element_builder`, and `data_style_tool`. Reach for `designer_tool` only when the task specifically needs the live canvas (current-page detection, interactive selection, page folders, component canvas view).
+- **Visual snapshots need Designer** — `element_snapshot_tool` is a Designer tool; if Designer isn't connected, fall back to describing changes from `query_elements`/tool response data instead of skipping the before/after check entirely.
 - **Batch changes need itemized preview** — if modifying multiple elements, list each change
 - Prefer Webflow's native layout tools (Grid, Flexbox) over manual positioning
 - Components shared across pages should be updated via `data_element_tool` scoped to the component (changes propagate to all instances)

--- a/plugins/webflow-skills/skills/flowkit-naming/SKILL.md
+++ b/plugins/webflow-skills/skills/flowkit-naming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webflow-mcp:flowkit-naming
-description: Apply Flowkit CSS naming system in Webflow. Use when creating classes, auditing existing naming, or building new components following Flowkit conventions. Flowkit is Webflow's official CSS framework with utility-first approach. Designer connection only needed to navigate/select pages and elements; class analysis and style creation run without it.
+description: Apply Flowkit CSS naming system in Webflow. Use when creating classes, auditing existing naming, or building new components following Flowkit conventions. Flowkit is Webflow's official CSS framework with utility-first approach. Runs headlessly against a page ID — no Designer connection required, except for the optional live-canvas conveniences (current page, interactive element selection).
 mcp-version: 2.0.1
 ---
 
@@ -13,13 +13,14 @@ Apply FlowKit CSS naming conventions in Webflow projects using Webflow Designer 
 **ALWAYS use Webflow MCP tools for all operations:**
 - Use Webflow MCP's `webflow_guide_tool` to get best practices before starting
 - Use Webflow MCP's `data_sites_tool` with action `list_sites` to identify the target site
-- Use Webflow MCP's `designer_tool` to get current page, switch pages, or select elements
-- Use Webflow MCP's `data_element_tool` to inspect current classes and apply new ones
-- Use Webflow MCP's `data_style_tool` to create and update FlowKit-compliant styles
+- Use Webflow MCP's `data_pages_tool` with action `list_pages` to find the target page by name or slug — headless, no Designer needed
+- Use Webflow MCP's `data_element_tool` to inspect current classes and apply new ones — headless, pass the page's ID directly
+- Use Webflow MCP's `data_style_tool` to create and update FlowKit-compliant styles — headless
 - Use Webflow MCP's `webflow_guide_tool` to understand supported style properties
+- Use Webflow MCP's `designer_tool` only if the user wants to work with whatever page is currently open in Designer, or wants to interactively select an element on the canvas
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection only required for `designer_tool` actions**: getting/switching the current page and selecting elements. Inspecting classes, creating styles, and applying classes (`data_element_tool`, `data_style_tool`) run without a Designer session.
+- **No Designer connection is required for the core workflow.** Getting the page, inspecting classes, creating styles, and applying classes all run headlessly against an explicit page ID. Designer is only needed for the optional `designer_tool` conveniences above.
 
 ## Instructions
 
@@ -29,44 +30,43 @@ Apply FlowKit CSS naming conventions in Webflow projects using Webflow Designer 
    - Auditing existing class names
    - Building complete page sections
    - Refactoring non-FlowKit classes to FlowKit
-2. **Connect to Designer**: Confirm user has Webflow Designer open and connected (needed to identify the current page)
-3. **Get current page**: Use Webflow MCP's `designer_tool` to identify current working page
-4. **Ask for scope**: Clarify which elements or sections to work with
+2. **Get target page**: Use Webflow MCP's `data_pages_tool` with action `list_pages` to find the page by name or slug — no Designer connection needed. If the user wants to work with whatever page they currently have open in Designer, use `designer_tool` with action `get_current_page` instead.
+3. **Ask for scope**: Clarify which elements or sections to work with
 
 ### Phase 2: Analysis (if auditing existing)
-5. **Get all elements**: Use Webflow MCP's `data_element_tool` to retrieve current page elements
-6. **Extract classes**: Identify all class names currently applied
-7. **Categorize issues**:
+4. **Get all elements**: Use Webflow MCP's `data_element_tool` to retrieve elements from the target page
+5. **Extract classes**: Identify all class names currently applied
+6. **Categorize issues**:
    - Missing `fk-` prefix
    - Incorrect case (uppercase/mixed case)
    - Wrong separators (underscores instead of hyphens)
    - Non-semantic naming
    - Inconsistent component structure
-8. **Generate audit report**: Show current vs suggested FlowKit-compliant names
+7. **Generate audit report**: Show current vs suggested FlowKit-compliant names
 
 ### Phase 3: Suggestion Generation
-9. **Apply FlowKit patterns**: Generate class names following FlowKit v2 conventions
-10. **Structure by type**:
+8. **Apply FlowKit patterns**: Generate class names following FlowKit v2 conventions
+9. **Structure by type**:
     - Component wrappers: `fk-[component]`
     - Child elements: `fk-[component]-[element]`
     - State modifiers: combo classes with `is-[state]`
     - Layout utilities: `fk-flex`, `fk-grid`, `fk-stack`
     - Spacing utilities: `fk-space-[size]`, `fk-py-[size]`, `fk-px-[size]`
     - Typography utilities: `fk-text-[style]`
-11. **Validate suggestions**: Ensure all suggestions follow FlowKit conventions
-12. **Show preview**: Display hierarchical structure with suggested classes
+10. **Validate suggestions**: Ensure all suggestions follow FlowKit conventions
+11. **Show preview**: Display hierarchical structure with suggested classes
 
 ### Phase 4: Application (if user confirms)
-13. **Create styles**: Use Webflow MCP's `data_style_tool` to create new FlowKit-compliant class styles
-14. **Update elements**: Use Webflow MCP's `data_element_tool` to apply classes to elements
-15. **Process in batches**: If many elements, process in groups of 10-15
-16. **Show progress**: Display which elements are being updated
+12. **Create styles**: Use Webflow MCP's `data_style_tool` to create new FlowKit-compliant class styles
+13. **Update elements**: Use Webflow MCP's `data_element_tool` to apply classes to elements
+14. **Process in batches**: If many elements, process in groups of 10-15
+15. **Show progress**: Display which elements are being updated
 
 ### Phase 5: Verification & Reporting
-17. **Verify application**: Check that classes were applied correctly
-18. **Generate report**: Show what was created/updated
-19. **Provide documentation**: Explain the FlowKit structure used
-20. **Suggest next steps**: Recommend additional FlowKit patterns to implement
+16. **Verify application**: Check that classes were applied correctly
+17. **Generate report**: Show what was created/updated
+18. **Provide documentation**: Explain the FlowKit structure used
+19. **Suggest next steps**: Recommend additional FlowKit patterns to implement
 
 ## FlowKit Naming Reference
 
@@ -800,8 +800,8 @@ If user has v1 FlowKit classes:
 - Show progress for large batches
 - If >50 elements, ask user to confirm batch size
 
-**Designer Connection:**
-- Verify Designer connection before getting/switching pages or selecting elements (`designer_tool`)
+**Designer Connection (only if using the optional `designer_tool` convenience):**
+- Class inspection, style creation, and element updates (`data_element_tool`, `data_style_tool`) never need Designer — this only applies if the user asked to work with the page currently open in Designer, or to interactively select elements
 - If connection lost mid-batch, pause and ask user to reconnect before the next `designer_tool` action
 - Save progress between batches
 
@@ -809,15 +809,17 @@ If user has v1 FlowKit classes:
 
 **Common Errors:**
 
-**1. Designer Not Connected:**
+**1. Designer Not Connected (only relevant when using `designer_tool`):**
 ```
-❌ Error: Cannot get/switch page or select elements - Designer not connected
+❌ Error: Cannot get current page or select elements - Designer not connected
 
 Solution:
 1. Open Webflow Designer
 2. Open the target site
 3. Connect to Designer in Claude Code
 4. Retry operation
+
+(Not needed for the default headless workflow — use `data_pages_tool` with `list_pages` instead.)
 ```
 
 **2. Class Already Exists:**
@@ -893,9 +895,8 @@ If too many utility classes on single element:
 Before considering FlowKit implementation complete:
 
 **Setup:**
-- [ ] Webflow Designer connected
 - [ ] Target site identified
-- [ ] Current page confirmed
+- [ ] Target page found (via `data_pages_tool` list_pages, or `designer_tool` if using the current open page)
 - [ ] Scope defined with user
 
 **Component Structure:**

--- a/plugins/webflow-skills/skills/flowkit-naming/SKILL.md
+++ b/plugins/webflow-skills/skills/flowkit-naming/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: webflow-mcp:flowkit-naming
-description: Apply Flowkit CSS naming system in Webflow. Use when creating classes, auditing existing naming, or building new components following Flowkit conventions. Flowkit is Webflow's official CSS framework with utility-first approach.
+description: Apply Flowkit CSS naming system in Webflow. Use when creating classes, auditing existing naming, or building new components following Flowkit conventions. Flowkit is Webflow's official CSS framework with utility-first approach. Designer connection only needed to navigate/select pages and elements; class analysis and style creation run without it.
+mcp-version: 2.0.1
 ---
 
 # Flowkit Naming System
@@ -12,13 +13,13 @@ Apply FlowKit CSS naming conventions in Webflow projects using Webflow Designer 
 **ALWAYS use Webflow MCP tools for all operations:**
 - Use Webflow MCP's `webflow_guide_tool` to get best practices before starting
 - Use Webflow MCP's `data_sites_tool` with action `list_sites` to identify the target site
-- Use Webflow MCP's `de_page_tool` to get current page and switch pages
-- Use Webflow MCP's `element_tool` to select elements and inspect current classes
-- Use Webflow MCP's `style_tool` to create and update FlowKit-compliant styles
-- Use Webflow MCP's `de_learn_more_about_styles` to understand supported style properties
+- Use Webflow MCP's `designer_tool` to get current page, switch pages, or select elements
+- Use Webflow MCP's `data_element_tool` to inspect current classes and apply new ones
+- Use Webflow MCP's `data_style_tool` to create and update FlowKit-compliant styles
+- Use Webflow MCP's `webflow_guide_tool` to understand supported style properties
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection required**: User must be connected to Webflow Designer for this skill to work
+- **Designer connection only required for `designer_tool` actions**: getting/switching the current page and selecting elements. Inspecting classes, creating styles, and applying classes (`data_element_tool`, `data_style_tool`) run without a Designer session.
 
 ## Instructions
 
@@ -28,12 +29,12 @@ Apply FlowKit CSS naming conventions in Webflow projects using Webflow Designer 
    - Auditing existing class names
    - Building complete page sections
    - Refactoring non-FlowKit classes to FlowKit
-2. **Connect to Designer**: Confirm user has Webflow Designer open and connected
-3. **Get current page**: Use Webflow MCP's `de_page_tool` to identify current working page
+2. **Connect to Designer**: Confirm user has Webflow Designer open and connected (needed to identify the current page)
+3. **Get current page**: Use Webflow MCP's `designer_tool` to identify current working page
 4. **Ask for scope**: Clarify which elements or sections to work with
 
 ### Phase 2: Analysis (if auditing existing)
-5. **Get all elements**: Use Webflow MCP's `element_tool` to retrieve current page elements
+5. **Get all elements**: Use Webflow MCP's `data_element_tool` to retrieve current page elements
 6. **Extract classes**: Identify all class names currently applied
 7. **Categorize issues**:
    - Missing `fk-` prefix
@@ -56,8 +57,8 @@ Apply FlowKit CSS naming conventions in Webflow projects using Webflow Designer 
 12. **Show preview**: Display hierarchical structure with suggested classes
 
 ### Phase 4: Application (if user confirms)
-13. **Create styles**: Use Webflow MCP's `style_tool` to create new FlowKit-compliant class styles
-14. **Update elements**: Use Webflow MCP's `element_tool` to apply classes to elements
+13. **Create styles**: Use Webflow MCP's `data_style_tool` to create new FlowKit-compliant class styles
+14. **Update elements**: Use Webflow MCP's `data_element_tool` to apply classes to elements
 15. **Process in batches**: If many elements, process in groups of 10-15
 16. **Show progress**: Display which elements are being updated
 
@@ -792,7 +793,7 @@ If user has v1 FlowKit classes:
 - Create base component classes first
 - Then create element classes
 - Finally create utility classes
-- Use `style_tool` in batches of 10-15 classes
+- Use `data_style_tool` in batches of 10-15 classes
 
 **Element Updates:**
 - Process elements in groups of 10-15
@@ -800,8 +801,8 @@ If user has v1 FlowKit classes:
 - If >50 elements, ask user to confirm batch size
 
 **Designer Connection:**
-- Always verify Designer connection before starting
-- If connection lost, pause and ask user to reconnect
+- Verify Designer connection before getting/switching pages or selecting elements (`designer_tool`)
+- If connection lost mid-batch, pause and ask user to reconnect before the next `designer_tool` action
 - Save progress between batches
 
 ### Phase 10: Error Handling
@@ -810,7 +811,7 @@ If user has v1 FlowKit classes:
 
 **1. Designer Not Connected:**
 ```
-❌ Error: Cannot create classes - Designer not connected
+❌ Error: Cannot get/switch page or select elements - Designer not connected
 
 Solution:
 1. Open Webflow Designer

--- a/plugins/webflow-skills/skills/link-checker/SKILL.md
+++ b/plugins/webflow-skills/skills/link-checker/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: webflow-mcp:link-checker
 description: Find and fix broken or insecure links across an entire site, including CMS content, to improve SEO and user experience. Audits HTTP/HTTPS issues and validates all internal and external links.
+mcp-version: 2.0.1
 ---
 
 # Link Checker
@@ -15,7 +16,7 @@ Audit and fix broken or insecure links across your Webflow site to improve SEO a
 - Use Webflow MCP's `data_sites_tool` with action `get_site` to retrieve site details
 - Use Webflow MCP's `data_pages_tool` with action `list_pages` to get all pages
 - Use Webflow MCP's `data_pages_tool` with action `get_page_content` to extract links from static pages
-- Use Webflow MCP's `data_pages_tool` with action `update_static_content` to fix links on static pages (requires Designer)
+- Use Webflow MCP's `data_pages_tool` with action `update_static_content` to fix links on static pages
 - Use Webflow MCP's `data_cms_tool` with action `get_collection_list` to get all CMS collections
 - Use Webflow MCP's `data_cms_tool` with action `get_collection_details` to get collection schemas
 - Use Webflow MCP's `data_cms_tool` with action `list_collection_items` to get CMS items with links
@@ -23,7 +24,7 @@ Audit and fix broken or insecure links across your Webflow site to improve SEO a
 - Use Webflow MCP's `data_cms_tool` with action `publish_collection_items` to publish fixed CMS items
 - DO NOT use any other tools or methods for Webflow operations
 - All tool calls must include the required `context` parameter (15-25 words, third-person perspective)
-- **Designer connection required** for static page link fixes
+- No Designer connection is required — both static page and CMS link fixes go through `data_` tools
 
 ## Instructions
 
@@ -101,7 +102,6 @@ Audit and fix broken or insecure links across your Webflow site to improve SEO a
 
 ### Phase 5: Execution & Confirmation
 15. **Apply fixes to static pages**: Use Webflow MCP's `data_pages_tool` with action `update_static_content`
-    - Requires Designer connection
     - Update link URLs in nodes
     - Process in batches of 20 links
 16. **Apply fixes to CMS content**: Use Webflow MCP's `data_cms_tool` with action `update_collection_items`
@@ -715,7 +715,6 @@ Needs manual review:
 **Static Page Updates:**
 ```
 Requirements:
-- Designer connection required
 - Use data_pages_tool with action update_static_content
 - Update nodes array with new URLs
 - Process in batches of 20 links per page
@@ -773,8 +772,8 @@ If any fixes failed:
 
 [1] Failed to update
     Location: Contact page
-    Reason: Designer connection lost
-    Action: Reconnect Designer and retry
+    Reason: Page content changed since last read (conflict)
+    Action: Re-fetch the page and retry
 
 [2] URL still broken
     Location: Blog post "Guide"


### PR DESCRIPTION
## Summary
- Migrates `designer-tools`, `asset-audit`, `accessibility-audit`, `flowkit-naming`, and `link-checker` to current Webflow MCP 2.0.1 tool/action names (e.g. `element_builder` -> `data_element_builder`, `style_tool` -> `data_style_tool`, the `element_tool`/`de_page_tool`/`de_component_tool` splits, `asset_tool` -> `data_assets_tool`, `get_image_preview(url)` -> `get_asset_preview(asset_id)`).
- Corrects stale "Designer connection required" claims — most operations route through headless `data_*` tools (`data_pages_tool`, `data_element_tool`, `data_element_builder`, `data_style_tool`, `data_component_tool` family) that take an explicit `siteId`/`pageId` and never touch a live Designer session. Only `designer_tool` genuinely requires Designer, scoped to reading/switching the current page, interactively selecting an element, creating page folders, and opening a component's canvas view.
- Fixes `element_snapshot_tool` framing: it is Designer-only (no `pageId`, captures the live canvas), with a `query_elements`-based fallback documented for when Designer isn't connected.
- Records `mcp-version: 2.0.1` in frontmatter on the five updated skills so future migrations can tell at a glance what version a skill targets.
- The other 22 skills in the repo were checked against the current tool list and confirmed already current — no changes needed.

## Test plan
- [ ] CI structural validation (marketplace/plugin configs, SKILL.md frontmatter) passes
- [ ] Spot-check updated skills against a live Webflow MCP 2.0.1 session for the Designer-required workflows (designer-tools, accessibility-audit, flowkit-naming)