### PR TITLE
[ALOOP-87] Add workflow skills to Webflow Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webflow Skills
 
-A collection of [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) for working with Webflow sites through the Webflow MCP server. Manage CMS content, audit site health, optimize assets, build in Webflow Designer, create Code Components, run Webflow CLI workflows, and safely publish changes.
+A collection of [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) for working with Webflow sites and workflows. Manage CMS content, audit site health, optimize assets, build in Webflow Designer, create Code Components, run Webflow CLI workflows, safely publish changes, write product content, and coordinate internal project work.
 
 ## Installing
 
@@ -113,6 +113,15 @@ Guided, educational skills from [Webflow University](https://university.webflow.
 | Skill | Description |
 |-------|-------------|
 | webflow-university:mcp-getting-started | Guided onboarding for your first Webflow MCP workflow — checks your connection, helps you pick a real task, coaches your prompt, and runs it with you |
+
+### Webflow Workflow Skills
+
+| Skill | Description |
+|-------|-------------|
+| webflow-workflow:webflow-content-design | Write or review Webflow product UX copy and content design |
+| webflow-workflow:sybg-guide | Create Since You've Been Gone announcement guides with Knock |
+| webflow-workflow:status-update | Generate project, team, or sprint status updates from GitHub, Slack, and Jira |
+| webflow-workflow:dx-team-lookup | Look up Webflow team membership from the DX data warehouse |
 
 ## Resources
 

--- a/plugins/webflow-skills/skills/dx-team-lookup/SKILL.md
+++ b/plugins/webflow-skills/skills/dx-team-lookup/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: webflow-workflow:dx-team-lookup
+description: Look up what team a person belongs to using the DX data warehouse. Accepts a git committer name, email address, GitHub username, or commit SHA. Use when asked "what team is X on?", "who does this commit belong to?", or "map this committer to a team".
+argument-hint: "[name, email, GitHub username, or commit SHA]"
+compatibility: Requires dx
+---
+
+# DX Team Lookup
+
+Look up what team a person belongs to using the DX developer productivity data warehouse.
+
+Verify `psql` is available: `which psql`. If missing: "Install with: `brew install postgresql`"
+
+## Step 1: Resolve the input
+
+**Commit SHA** (e.g. `abc1234`):
+```bash
+git log -1 --format="%ae|||%an" <SHA>
+```
+Use the extracted email/name for the lookup.
+
+**No argument**: use HEAD commit:
+```bash
+git log -1 --format="%ae|||%an"
+```
+
+**GitHub noreply email** (format: `12345+username@users.noreply.github.com`):
+Extract the GitHub username from between `+` and `@`. Use that as the search term against `github_username`.
+
+**Name, email, or username**: use directly as the search term.
+
+## Step 2: Run the lookup
+
+The query is extracted into a checked-in script to avoid agent transcription errors:
+
+```bash
+bash ~/.claude/skills/dx-team-lookup/scripts/lookup.sh "<search_term>"
+```
+
+Replace `<search_term>` with the resolved value from Step 2. If this skill is installed in a different agent-specific directory, substitute that installed skill path.
+
+For noreply emails, run two passes: one with the GitHub username (e.g. `Roach`), and if no result, one with the numeric ID prefix stripped full name if available.
+
+## Step 3: Output
+
+**Match found:**
+```
+Person:  Arafat Abdulla (arafat.abdulla@webflow.com)
+GitHub:  arafat-webflow
+Team:    Subscription & Payments
+Pillar:  Growth Pillar
+As of:   2026-03-07
+
+(Source: DX data warehouse)
+```
+
+If `pillar` is NULL (team has no parent in DX), omit the Pillar line entirely rather than printing blank.
+
+**Multiple matches:**
+```
+Multiple matches for "zhang":
+
+  Daniel Zhang  (daniel.zhang@webflow.com)  — Code Gen
+  Alice Zhang   (alice.zhang@webflow.com)   — Platform Engineering
+
+Tip: re-run with a full email or GitHub username for an exact match.
+```
+
+**No match:**
+```
+No match found for: "fbaralle"
+
+This person may be an external contributor, contractor, former employee,
+a recent hire not yet in DX, or a bot/automation account. The DX
+warehouse only includes current Webflow employees.
+```
+
+## Future improvements
+
+- **Agent-initiated outreach**: Once team membership is known, agents could use this data to route review requests, context questions, or approval workflows to the right people automatically.
+
+## Key rules
+
+- **Never print the value of `$DX_WAREHOUSE_DSN`** — it contains credentials.
+- If `psql` returns a connection error, show the error message but not the DSN.
+- The `as_of` date reflects the latest DX snapshot that includes this person. Team membership is synced from Workday quarterly (aligned with the quarterly survey), so data may lag by up to a quarter for org changes.
+- If a person isn't found, that's a valid result (external contributor, contractor, former employee, recent hire, or bot/automation account).
+- Common bot usernames in Webflow's git history (e.g. `wolfdew`, `renovate`, `github-actions`) will never appear in DX — skip lookup for these rather than treating a no-match as inconclusive.

--- a/plugins/webflow-skills/skills/dx-team-lookup/scripts/lookup.sh
+++ b/plugins/webflow-skills/skills/dx-team-lookup/scripts/lookup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# DX team lookup — resolves a name, email, or GitHub username to team + pillar.
+#
+# Usage:
+#   bash ~/.claude/skills/dx-team-lookup/scripts/lookup.sh "<search_term>"
+#
+# Outputs CSV: name,email,github_username,team,pillar,as_of
+
+set -euo pipefail
+
+SEARCH_TERM="${1:?Usage: lookup.sh <search_term>}"
+
+if [[ -z "${DX_WAREHOUSE_DSN:-}" ]]; then
+  DX_WAREHOUSE_DSN=$(AWS_PROFILE=dev-publish-only ops/secret-manager get-secret-value \
+    --secret-id arn:aws:secretsmanager:us-east-1:735392911607:secret:localdev-secrets/dx-secrets-b1ae64d-xUIxez \
+    2>/dev/null) || {
+    cat >&2 <<'BANNER'
++------------------------------------------------------------------+
+| Could not fetch DX warehouse credentials from AWS                |
+|                                                                   |
+| Your SSO session may be expired. Try:                            |
+|   aws sso login --sso-session wf-session                         |
+|                                                                   |
+| Then re-run this skill. No manual setup is required —            |
+| credentials are fetched automatically via dev-publish-only.      |
++------------------------------------------------------------------+
+BANNER
+    exit 1
+  }
+fi
+
+# Pipe query via stdin so psql processes :'var' substitution client-side.
+# (The -c flag sends queries directly to the server, bypassing psql variable substitution.)
+psql "$DX_WAREHOUSE_DSN" --csv -v search_term="$SEARCH_TERM" <<'ENDSQL'
+WITH latest_per_user AS (
+  SELECT vtm.user_id, MAX(vd.date) AS latest_date
+  FROM public.dx_versioned_team_members vtm
+  JOIN public.dx_versioned_teams vt ON vtm.versioned_team_id = vt.id
+  JOIN public.dx_versioned_team_dates vd ON vt.versioned_team_date_id = vd.id
+  GROUP BY vtm.user_id
+)
+SELECT
+  u.name,
+  u.email,
+  u.github_username,
+  vt.name AS team,
+  COALESCE(
+    CASE WHEN ggpt.parent_id IS NULL AND ggpt.is_parent THEN ggpt.name END,
+    CASE WHEN  gpt.parent_id IS NULL AND  gpt.is_parent THEN  gpt.name END,
+    CASE WHEN   pt.parent_id IS NULL AND   pt.is_parent THEN   pt.name END,
+    CASE WHEN   vt.parent_id IS NULL AND   vt.is_parent THEN   vt.name END
+  ) AS pillar,
+  vd.date AS as_of
+FROM public.dx_users u
+JOIN latest_per_user lpu ON lpu.user_id = u.id
+JOIN public.dx_versioned_team_members vtm ON vtm.user_id = u.id
+JOIN public.dx_versioned_teams vt ON vtm.versioned_team_id = vt.id
+JOIN public.dx_versioned_team_dates vd ON vt.versioned_team_date_id = vd.id AND vd.date = lpu.latest_date
+LEFT JOIN public.dx_versioned_teams pt   ON vt.parent_id  = pt.id   AND pt.versioned_team_date_id  = vd.id
+LEFT JOIN public.dx_versioned_teams gpt  ON pt.parent_id  = gpt.id  AND gpt.versioned_team_date_id = vd.id
+LEFT JOIN public.dx_versioned_teams ggpt ON gpt.parent_id = ggpt.id AND ggpt.versioned_team_date_id = vd.id
+WHERE u.deleted_at IS NULL
+  AND (
+    u.name ILIKE '%' || :'search_term' || '%'
+    OR u.email ILIKE '%' || :'search_term' || '%'
+    OR u.github_username ILIKE '%' || :'search_term' || '%'
+  );
+ENDSQL

--- a/plugins/webflow-skills/skills/status-update/SKILL.md
+++ b/plugins/webflow-skills/skills/status-update/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: webflow-workflow:status-update
+description: Generate a project, team, or sprint status update. Use for weekly status, project updates, sprint updates, or summaries of shipped work from Jira, GitHub, and Slack.
+argument-hint: "[optional: week offset, e.g. '-1' for last week]"
+compatibility: Requires gh, slack, and atlassian
+---
+
+# Status Update
+
+Generate a concise status update by collecting project name, Slack channel, Jira epic, GitHub authors/teams, and repo, then pulling PRs, Slack context, and Jira tickets.
+
+## Step 0: Collect Config
+
+Before doing anything else, check whether the user already provided the required inputs inline (e.g. "weekly status for #proj-components-and-bindings-api, STRUCT-1234, authors: alice, bob"). If all values are present, proceed directly to Step 1. Otherwise, ask the user for any that are missing.
+
+**Required inputs:**
+
+| Input | Description | Default / example |
+|---|---|---|
+| `PROJECT_NAME` | Human-readable project/team name for the update header | e.g. "Components & Bindings API" |
+| `PROJECT_STATUS` | Current project status | One of: `On track`, `At risk`, `Off track` |
+| `SLACK_CHANNEL` | Slack channel ID **or** channel name/URL | e.g. `C0AFFPBMCAJ` or `#proj-components-and-bindings-api` |
+| `JIRA_EPIC` | Jira epic key (optional — skip if no Jira epic exists) | e.g. `STRUCT-2951` |
+| `GH_AUTHORS` | Comma-separated GitHub usernames **or** team handles to include | e.g. `alice, lebron` or `@webflow/agent-loop` |
+| `GH_REPO` | GitHub repo in `owner/repo` format | Default: infer from `gh repo view --json nameWithOwner` |
+| `PERIOD` | Time period to cover (optional) | Default: `7` (days). Examples: `14` for biweekly, `30` for monthly, `90` for quarterly |
+
+**Resolving `GH_AUTHORS`:**
+
+If a value starts with `@`, treat it as a GitHub team handle. Resolve it to individual members:
+
+```bash
+# Resolve team handle to member list (e.g. @webflow/agent-loop → alice, bob, charlie)
+gh api orgs/webflow/teams/agent-loop/members --jq '.[].login'
+```
+
+Mix-and-match is supported: `@webflow/agent-loop, extra-contributor`.
+
+Resolve `SLACK_CHANNEL` to a channel ID if a name or URL was provided:
+
+```
+Use Slack tools to search for the matching channel name.
+```
+
+## Workflow
+
+### Step 1: Determine the date range
+
+Use `$PERIOD` to calculate the lookback window (default: 7 days). If the user passes a week offset (e.g. `-1`), shift the window back by that many periods.
+
+```bash
+# Calculate date range based on PERIOD (default 7 days)
+PERIOD=${PERIOD:-7}
+START_DATE=$(date -v-${PERIOD}d +%Y-%m-%d)
+END_DATE=$(date +%Y-%m-%d)
+START_DATE_FORMATTED=$(date -v-${PERIOD}d +"%-B %-d")  # e.g. "March 16"
+echo "Date range: $START_DATE to $END_DATE"
+# PERIOD_LABEL: "Week" (7), "Two weeks" (14), "Month" (30), "Quarter" (90), or "{N} days"
+```
+
+### Step 2: Gather PRs from GitHub (primary source)
+
+Search for PRs authored by each team member in the date range. Run one command per author in parallel, substituting `$GH_REPO` and each author from `$GH_AUTHORS`:
+
+```bash
+# Merged PRs (include body to extract Jira ticket)
+gh pr list --repo $GH_REPO --author <author> --state merged --search "merged:>=$START_DATE" --json number,title,url,body,mergedAt --limit 30
+
+# Open / Draft PRs (currently active)
+gh pr list --repo $GH_REPO --author <author> --state open --json number,title,url,body,isDraft --limit 20
+```
+
+#### Extract Jira ticket from each PR
+
+For each PR, parse the `body` field to find the Jira ticket key. Look for patterns like:
+- A Jira URL: `https://webflow.atlassian.net/browse/PROJ-XXXX`
+- A ticket key in text: `STRUCT-1234`, `DEVPL-5678`, `IDSC-999`, etc.
+- The branch name often contains the ticket key, e.g. `STRUCT-3606-some-description`
+
+Extract the **first matching Jira ticket key**. If no ticket is found, fall back to the PR number and URL.
+
+For each PR, determine if it's related to `$PROJECT_NAME`. Relevance signals:
+- Branch or title mentions keywords related to the project
+- Jira ticket in the branch matches `$JIRA_EPIC` or its child tickets (if provided)
+
+**When in doubt, include the PR** — the user will manually exclude irrelevant ones.
+
+### Step 3: Check Slack for additional context (secondary)
+
+Use Slack tools to read recent messages from the project channel:
+
+```
+Read the Slack channel with `channel_id: "$SLACK_CHANNEL"` and `limit: 50`.
+```
+
+Scan for:
+- Decisions made (e.g. "we decided to...", "going with...", "aligned on...")
+- Documents or specs shared (Confluence links, Google Docs, Figma links)
+- Blockers mentioned
+- Notable discussions about direction or scope changes
+
+Summarize any relevant findings briefly (1-2 bullets max). Skip if nothing notable.
+
+### Step 4: Check Jira epic for context (secondary)
+
+Skip this step if no `$JIRA_EPIC` was provided.
+
+Use Jira tools to check the epic:
+
+```
+Read the Jira issue with `issueIdOrKey: "$JIRA_EPIC"`.
+```
+
+Optionally search for child issues updated this week:
+
+```
+Search Jira with JQL: `parent = $JIRA_EPIC AND updated >= '-7d' ORDER BY updated DESC`, limit 20.
+```
+
+Use Jira to supplement context — e.g. upcoming milestones, status changes, or tickets that moved but didn't have PRs.
+
+### Step 5: Categorize work
+
+Sort all gathered items into two buckets:
+
+1. **What got done** — Merged PRs and completed work
+2. **What is next** — Open/draft PRs, upcoming Jira tickets, and planned work mentioned in Slack
+
+### Step 6: Format the status update
+
+Output the update in this exact format:
+
+```
+**{PROJECT_NAME} — {PERIOD_LABEL} of {START_DATE_FORMATTED}**
+
+**Status**: {PROJECT_STATUS}
+
+**What got done**
+- {Brief description of merged PR or completed work} ([PROJ-XXXX](https://webflow.atlassian.net/browse/PROJ-XXXX))
+- ...
+
+**What's next**
+- {Brief description of open/draft PR or upcoming work} ([PROJ-XXXX](https://webflow.atlassian.net/browse/PROJ-XXXX))
+- ...
+
+{Optional: 1-2 bullets of notable Slack decisions or docs, only if relevant}
+```
+
+**Linking rules:**
+- Link to the Jira ticket extracted from the PR description, not the PR itself.
+- Format: `[PROJ-XXXX](https://webflow.atlassian.net/browse/PROJ-XXXX)`
+- If multiple PRs share the same Jira ticket, combine them into one bullet.
+- If no Jira ticket is found in a PR, fall back to the PR link: `([#number](pr_url))`
+- If no `$JIRA_EPIC` was provided, omit Jira links entirely and always use PR links.
+
+### Step 7: Present to user and offer to post
+
+Show the formatted update and ask:
+> "Here's the draft. Want me to adjust anything, or shall I post it to Slack?"
+
+Recommend sending it to themselves first to test. If the user approves, post to the Slack channel:
+
+```
+Send the formatted update to Slack with `channel_id: "$SLACK_CHANNEL"`.
+```
+
+## Key Instructions
+
+- **Be concise** — each bullet should be one short line. No one wants to read a wall of text.
+- **Do NOT include author names** — just describe the work and its status.
+- **GitHub is the source of truth** — Slack and Jira are supplementary context only.
+- **When in doubt, include a PR** — the user will manually remove irrelevant items.
+- **Status is user-provided** — always use the `$PROJECT_STATUS` value the user gave; never infer or override it.
+- **Link to Jira tickets, not PRs** — extract the ticket key from the PR description/branch and link to it. Fall back to PR link only if no ticket is found.
+- **Do not post to Slack without explicit user approval.**

--- a/plugins/webflow-skills/skills/sybg-guide/SKILL.md
+++ b/plugins/webflow-skills/skills/sybg-guide/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: webflow-workflow:sybg-guide
+description: Create a Since You've Been Gone (SYBG) modal with Knock Guides. Use for feature announcement guides, Knock Guide setup, targeting, scheduling, and rollout gates.
+argument-hint: "[guide-name]"
+---
+
+# Create a New SYBG Guide in Knock
+
+Set up Knock Guide creation, audience targeting, tenancy mode, runtime conditions, URL activation, content setup, scheduling, and prioritization.
+
+## Safety checks
+- Always make changes and commits in the `development` environment only.
+- Do not modify, update, archive, or delete any existing guides. Only create a new guide for the requested announcement.
+- Always prompt the users to go to `https://dashboard.knock.app/webflow/development/guides` to verify the changes and prompt them to promote to `production` after validating visually in the dashboard.
+- If you encounter issues, raise a ticket in **#triage-scale-lifecycle** Slack channel.
+
+## References
+- Knock Agent Toolkit: https://docs.knock.app/developer-tools/agent-toolkit/tools-reference
+- Knock Management API Guide Upsert: https://docs.knock.app/mapi-reference/guides/upsert
+
+## Prerequisites
+
+### Knock Integration (Required)
+
+The Knock integration lets agents create and commit guides directly via API — skipping manual dashboard steps for guide creation, message type inspection, committing, and promoting.
+
+For example, set up the Knock connector in Claude Code:
+```
+claude mcp add --transport http knock https://mcp.knock.app/mcp
+```
+Then authenticate via OAuth. In other agent environments, use the available connector setup flow.
+
+**Knock tools used by this skill:**
+
+| Tool | When used |
+|------|-----------|
+| `listEnvironments` | Confirm available environments |
+| `createOrUpdateGuide` | Create or update the guide |
+| `commitAllChanges` | Commit guide config in development |
+| `searchDocumentation` | Look up Knock API fields on demand |
+
+
+## Step I: Guide Name
+
+- Prompt the user to enter the name for the guide. This name typically maps to the name of the feature that is to be announced.
+- With the guide name, generate a guide key which acts as a human-readable unique identifier for the guide. Convert the guide name to kebab-case for the guide key.
+
+## Step II: Guide Message
+
+- The Message Type for the SYBG guide is `since-youve-been-gone`. It has only one variant: `default`.
+- The schema for the `default` variant of the `since-youve-been-gone` message type is:
+   ```json
+   {
+      "fields": [
+         {
+               "key": "title",
+               "label": "Full Title",
+               "settings": {
+                  "default": "Release name here",
+                  "description": "The title of the product update",
+                  "max_length": 100,
+                  "min_length": 1,
+                  "required": true
+               },
+               "type": "text"
+         },
+         {
+               "key": "titleCondensed",
+               "label": "Condensed Title",
+               "settings": {
+                  "default": "Short release name",
+                  "description": "The condensed version of the title",
+                  "max_length": 26,
+                  "min_length": 1,
+                  "required": true
+               },
+               "type": "text"
+         },
+         {
+               "action": {
+                  "key": "action",
+                  "label": "Image action",
+                  "settings": {
+                     "default": "",
+                     "required": false
+                  },
+                  "type": "text"
+               },
+               "alt": {
+                  "key": "alt",
+                  "label": "Alt text",
+                  "settings": {
+                     "default": "Short description of the image",
+                     "required": true
+                  },
+                  "type": "text"
+               },
+               "key": "image",
+               "label": "Image",
+               "settings": {
+                  "required": true
+               },
+               "type": "image",
+               "url": {
+                  "key": "url",
+                  "label": "Image URL",
+                  "settings": {
+                     "default": "https://d3e54v103j8qbb.cloudfront.net/since-youve-been-gone/sybg-single.png",
+                     "required": true
+                  },
+                  "type": "url"
+               }
+         },
+         {
+               "key": "content",
+               "label": "Content",
+               "settings": {
+                  "default": "Write the description of the release here!",
+                  "required": true
+               },
+               "type": "markdown"
+         },
+         {
+               "action": {
+                  "key": "action",
+                  "label": "Action or URL",
+                  "settings": {
+                     "default": "https://webflow.com/update",
+                     "required": false
+                  },
+                  "type": "text"
+               },
+               "key": "primaryButton",
+               "label": "Primary Button",
+               "settings": {
+                  "required": false
+               },
+               "text": {
+                  "key": "text",
+                  "label": "Text",
+                  "settings": {
+                     "default": "Learn more",
+                     "required": false
+                  },
+                  "type": "text"
+               },
+               "type": "button"
+         },
+         {
+               "action": {
+                  "key": "action",
+                  "label": "Action or URL",
+                  "settings": {
+                     "default": "",
+                     "required": false
+                  },
+                  "type": "text"
+               },
+               "key": "secondaryButton",
+               "label": "Secondary Button",
+               "settings": {
+                  "required": false
+               },
+               "text": {
+                  "key": "text",
+                  "label": "Text",
+                  "settings": {
+                     "default": "",
+                     "required": false
+                  },
+                  "type": "text"
+               },
+               "type": "button"
+         }
+      ],
+      "key": "default",
+      "name": "Default"
+   }
+   ```
+- Prompt the user to enter the title for the guide. The title should be limited to a 100 characters.
+- Prompt the user to enter the condensed title for the guide. The condensed title should be limited to 26 characters.
+- Prompt the user to enter the image URL for the guide. The image should be a high resolution image (>= 1200x630) and should be optimized for web (<= 100kb). This input is optional, and if no image URL is provided, then default to: `https://d3e54v103j8qbb.cloudfront.net/since-youve-been-gone/sybg-single.png`
+- Prompt the user to enter the alt text for the image. If no alt text is provided, then default to: "Webflow product update".
+- Prompt the user to enter the content for the guide. This represents the "body" of the guide.
+- Prompt the user to enter the text of the Primary CTA Button. This input is optional, and if no text is provided, then default to: "Learn more".
+- Prompt the user to enter the URL of the Primary CTA Button. This input is optional, and if no URL is provided, then default to: "https://webflow.com/update".
+- Prompt the user to enter the text of the Secondary CTA Button. This input is optional, and if no text is provided, then default to: "".
+- Prompt the user to enter the URL of the Secondary CTA Button. This input is optional, and if no URL is provided, then default to: "".
+
+## Step III: Guide Targeting
+
+### III-A. Choose Audience
+
+Select the set of Users eligible to receive the Guide. Audiences can be:
+- All users
+- A specific list (e.g., users enrolled in a beta, imported CSV)
+- A dynamically computed segment
+
+- Default the audience to "All users". If the user wants to target a specific audience, then prompt the user to enter the audience key. The list of audiences can be found at: `https://dashboard.knock.app/webflow/development/audiences`.
+
+### III-B. Tenancy Strict Mode
+
+Enable this when a Guide should only appear to a User when they are in a **specific workspace**.
+
+| Mode | Behavior |
+|------|----------|
+| **Enabled** | Knock checks for an exact `{userId, tenantId}` match. User must be in the Audience *with that specific workspace's tenantId*. |
+| **Disabled** | Knock only checks `userId`. User sees the Guide in **all** their workspaces if present in the Audience. |
+
+A Knock `Tenant` maps 1:1 to a Webflow Workspace. Enable strict mode when the Guide is workspace-specific; leave it off for account-level announcements.
+
+Ask the user: "For a particular user, should this guide appear to this user across all their workspaces, or only in specific workspaces?". If the user wants the guide to appear in all workspaces, then set the tenancy strict mode to `false`. If the user wants the guide to appear in specific workspaces, then set the tenancy strict mode to `true`.
+
+In most cases, the ``tenancy strict mode`` will most likely be set to `false` for SYBG guides.
+
+### III-C. Activation (URL Targeting)
+
+Specify which URLs the Guide should appear on.
+
+- **Simple**: Enter a path (e.g., `/dashboard`) to restrict to that exact page.
+- **Advanced**: Use regular expressions to match multiple paths, or add query parameter conditions.
+
+Leave blank to show the Guide on all pages.
+
+## Step IV: Create and commit to `development` environment
+
+1. Call `createOrUpdateGuide` in `development` with the appropriate payload. For reference: https://docs.knock.app/mapi-reference/guides/upsert.
+2. Call `commitAllChanges` on the `development` environment to save the guide configuration.

--- a/plugins/webflow-skills/skills/webflow-content-design/SKILL.md
+++ b/plugins/webflow-skills/skills/webflow-content-design/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: webflow-workflow:webflow-content-design
+description: Write or review Webflow product UX copy and content design. Use for buttons, tooltips, modals, errors, empty states, SYBG, updates posts, terminology, or tone.
+---
+
+# Content Design & UX Writing
+
+Help Webflow engineers, product designers, and PMs write customer-facing content that's on-brand, consistent, and doesn't need to bounce back from the content design team. Covers voice, tone, grammar, product terminology, Spring component-specific writing rules, release announcements, help documentation, and University articles. The Content Design team can be reached on **#content-design** in Slack — reference this channel when flagging issues or when the user needs human guidance.
+
+---
+
+## How This Skill Works
+
+This skill supports two modes and four content types. Start by figuring out which mode and type the user needs, then follow the corresponding workflow.
+
+### Modes
+1. **Write** — Generate new copy from a feature description, Jira ticket, or conversation
+2. **Audit** — Review existing copy against the guidelines and return a corrected version with brief notes on what changed
+
+### Content Types
+1. **In-product UI copy** — Buttons, tooltips, modals, error messages, empty states, onboarding, dialogs, dashboards, forms, notifications, banners, toasts, tabs, tags, accordions, links, badges
+2. **SYBG modal content** — "Since You've Been Gone" entries displayed in the Webflow Dashboard via Knock Guides
+3. **webflow.com/updates posts** — Feature release announcements on the public updates page
+4. **Help documentation** — Webflow University articles and tutorials
+
+---
+
+## Tradeoff Prioritization
+
+When guidelines conflict, follow this priority order:
+
+**1. Clarity over brevity.** If a 3-word button label is ambiguous but a 4-word version is clear, go with clarity.
+
+**2. User-centeredness over brand voice.** If being "bold" would confuse the user or bury the action, dial it back.
+
+**3. Accessibility over aesthetics.** If a concise link label fails screen reader users, add a descriptive `aria-label` even though it adds engineering work. If a tooltip is the only way to explain an icon-only button, consider whether a visible text label would serve more users.
+
+**4. Consistency over local optimization.** If every other button in a flow says "Create" and this one says "Make," align with the pattern.
+
+When making a tradeoff, flag it briefly — note what was prioritized and why.
+
+---
+
+## Step 1: Understand the Request
+
+Accept input flexibly. The user might:
+- Describe the feature and context conversationally
+- Paste a Jira ticket or product brief
+- Paste existing copy they want reviewed
+- Share a screenshot or Figma link
+- Point you to a file, component, or PR in the codebase
+
+If the content type isn't obvious, ask. If you need more context to write well, ask — but keep it to 1-2 focused questions, not an interrogation.
+
+Key things to establish:
+- **Content type** (UI copy, SYBG, /updates, help doc)
+- **Where it appears** (which screen, surface, or page)
+- **What the user is doing** when they see this content
+- **What the user needs to understand or do next**
+- **Severity/emotional context** (especially for errors and alerts)
+
+## Step 2: Investigate Context Before Writing
+
+Copy doesn't exist in a vacuum. A tooltip on a button means nothing until you understand what the button does, what happened before the user got there, what happens after they click it, and what could go wrong. The difference between good and great copy is the depth of understanding behind it.
+
+### What to investigate
+
+**Look at the surrounding code.** When the request involves in-product copy (strings, error messages, tooltips, modals, empty states), look at the component and its neighbors:
+- What component renders this copy? What props does it receive? What state triggers it?
+- What's the user flow — what screen or action came before this, and what comes after?
+- Are there related strings nearby (other error states, loading states, success states) that this copy should be consistent with?
+- Is this copy conditional? What are the different states it could appear in?
+- Are there existing copy patterns in the same feature area you should match?
+
+**Understand the job to be done.** For every piece of copy, ask: what does the user need to understand or do *right now*, in this exact moment? The answer shapes everything — length, tone, specificity, and what to leave out.
+
+**Check the conversation and PR context.** Often the richest context is in the current conversation, the PR description, or linked Jira tickets. Look for the *why* behind the feature, edge cases, and design constraints (truncation limits, conditional rendering, etc.).
+
+**Look at the user's journey holistically.** If you can, trace the path a user would take to reach this copy to avoid repeating information and match the tone progression of the flow.
+
+### When to skip deep investigation
+Not every request needs a full codebase audit. If someone says "write a SYBG for this feature, here's the brief" — you probably have enough. The more ambiguous or contextual the copy, the more investigation pays off. The more standalone the content, the less you need to dig.
+
+## Step 3: Read the Relevant References
+
+Before writing or auditing, read the reference files that apply to the content type.
+
+**Always read:**
+- `references/voice-and-tone.md` — The four voice dimensions and how to apply them
+- `references/grammar-mechanics.md` — Capitalization, punctuation, pronouns, verb tenses, numbers, and more
+
+**Read based on content type:**
+- For **UI copy**: read `references/content-patterns.md` (Section 1), `references/content-checklist.md`, and `references/components.md`
+- For **SYBG**: read `references/content-patterns.md` (Section 2)
+- For **/updates posts**: read `references/content-patterns.md` (Section 3)
+- For **help docs**: read `references/content-patterns.md` (Section 4)
+
+**Read when you need a terminology gut-check:**
+- `references/terminology.md` — The Webflow A-Z for capitalization and usage of every product term
+
+## Step 4: Write or Audit
+
+### Writing Mode
+
+Generate **2-3 variants** for the user to choose from. Each variant should:
+- Follow all applicable guidelines from the reference files
+- Reflect the context you gathered in Step 2 — the user's moment, emotional state, and job to be done should shape the copy, not just the guidelines
+- Be labeled with a short description of its angle (e.g., "More concise," "Emphasizes user benefit," "Bolder tone")
+- Be ready to ship — not a rough draft
+
+For UI copy, output the exact strings (button text, headline, body, tooltip, etc.) organized by component. Don't write paragraphs explaining what the copy should say — write the actual copy. If your investigation in Step 2 revealed related strings that should be updated for consistency, flag them.
+
+For longer-form content (SYBG, /updates, help docs), still provide 2-3 variants but it's fine if they share the same structure and differ mainly in tone, phrasing, or emphasis.
+
+### Audit Mode
+
+When the user pastes existing copy:
+1. Return a **corrected version** — the copy as it should read
+2. Below it, include a **brief changelog** — a short bulleted list of what you changed and why, referencing the specific guideline (e.g., "Changed to sentence case per Webflow capitalization standards," "Rewrote to active voice," "Replaced 'please' — can undermine authority in error messages")
+
+Don't lecture. Keep the changelog tight and useful.
+
+---
+
+## Component Quick-Reference
+
+When a user shares a Figma prototype or mentions a component name, identify the Spring component and read the full reference at `references/components.md`.
+
+| Component | Max length | Key rule |
+|-----------|-----------|----------|
+| **Button** | 3 words | Describe exactly what happens on click. No articles. |
+| **Badge** | 1–2 words | Concise attention-grabbing. No "alpha" tags. |
+| **Banner** | 2 sentences | Must communicate both the problem AND the solution. |
+| **Toast** | A few words | Never truncate. Drop "successfully." |
+| **Tooltip** | ~2 lines | No interactive elements. Ancillary info only. |
+| **Modal heading** | Short | Confirmations can be questions. Others: declarative. No period. |
+| **Modal body** | 3 lines max | Focus on consequences. Don't repeat heading as question. |
+| **Tab** | 1–2 words | Same part of speech across all tabs. |
+| **Tag** | 1–2 words | Metadata labels — concise and descriptive. |
+| **Form label** | 1–2 words | Describe what to input. Label visible above field. |
+| **Menu item** | 1–2 words (with desc) or 2 lines (without) | User should know exactly what happens on click. |
+| **Link** | Brief standalone sentence | Describe where the user goes. Avoid generic "Learn more." No trailing period. |
+| **Error message** | Concise | State problem + resolution. No "please." Don't blame the user. |
+| **Empty state** | Short | Don't point out the obvious. Direct to actions that populate. |
+| **Accordion label** | Concise | Describe what's inside. Don't repeat in expanded content. |
+
+---
+
+## Worked Examples
+
+### Generating copy: confirmation modal
+
+**Prompt:** "I'm designing a confirmation modal for when someone tries to delete a Workspace."
+
+**Output:**
+
+| Slot | Copy |
+|------|------|
+| Title | Delete this Workspace? |
+| Body | This will permanently remove the Workspace, all its sites, and member access. This can't be undone. |
+| Secondary button | Cancel |
+| Primary button | Delete Workspace |
+
+Guidelines applied: Sentence case, "Workspace" capitalized, title is a question (confirmation modal), body focuses on consequences, buttons ≤3 words and clearly differentiated, no "Are you sure?" pattern.
+
+### Reviewing copy: empty state audit
+
+**Prompt:** "Review this empty state — Heading: 'There's Nothing Here Yet!' / Body: 'You haven't created any activity. Click below to start.' / Button: 'Start Creating Activity Now'"
+
+**Review:**
+- **Heading** — three issues: title case (should be sentence case), exclamation point (not appropriate for empty state), points out the obvious. → **"Start tracking site changes"**
+- **Body** — two issues: "Click below" not accessible (assumes mouse), blames user for automatic activity. → **"Activity will appear here as changes are made to this site."**
+- **Button** — exceeds 3-word max, "Creating Activity" doesn't make sense (activity is automatic). → **"Open Designer"** or remove CTA entirely.
+
+---
+
+## After Writing
+
+Once you've delivered variants or an audit, be ready for:
+- "Can you make it shorter / punchier / more empathetic?"
+- "Which one do you recommend?"
+- "Can you write the tooltip too?"
+- "Now write the SYBG for this same feature"
+
+The user might work through multiple content types for the same feature in one session. That's the ideal workflow — keep context and stay consistent across surfaces.
+
+---
+
+## Flagging
+
+Two situations require flagging:
+
+**1. Guideline deviation.** When copy conflicts with these guidelines (wrong case, missing Oxford comma, "please" in an error, wrong terminology, etc.), correct it and explain the specific rule. No escalation needed for straightforward corrections.
+
+**2. New patterns or genuine ambiguity.** When a content decision can't be resolved by these guidelines — a new component pattern, a tradeoff with no clear winner, a terminology question not in the A-Z, or a deviation the user insists on keeping — surface this message:
+
+> 💬 **This might need a human eye.** This decision goes beyond what the content guidelines cover. Reach out to the Content Design team on **#content-design** in Slack — they can help confirm the right direction.

--- a/plugins/webflow-skills/skills/webflow-content-design/references/components.md
+++ b/plugins/webflow-skills/skills/webflow-content-design/references/components.md
@@ -1,0 +1,578 @@
+# Component Writing Guidance
+
+Detailed content rules for each UI component, mapped to the Spring design system. Each section includes the component's **Spring anatomy** (the structural slots where content lives) and the **content rules** for writing within those slots.
+
+When reviewing a Figma prototype, identify the Spring component name (e.g., `Toast`, `Note`, `EmptyState`) and use the anatomy below to understand which slots need copy and what constraints apply.
+
+## Table of contents
+- [Accordion](#accordion) | [Buttons](#buttons) | [Badges](#badges) | [Banner](#banner)
+- [Empty state & Loading state](#empty-state--loading-state) | [Error messages](#error-messages)
+- [Form labels](#form-labels) | [Links](#links) | [List boxes](#list-boxes) | [Menus](#menus)
+- [Modal (Dialog)](#modal-dialog) | [Note](#note) | [Notifications](#notifications)
+- [Onboarding Popover](#onboarding-popover) | [Popover](#popover)
+- [Radio card](#radio-card) | [Switch box](#switch-box) | [Tabs](#tabs) | [Tables](#tables)
+- [Tag](#tag) | [Toast](#toast) | [Tooltip](#tooltip) | [Upsell banner](#upsell-banner)
+
+---
+
+## Accordion
+
+### Spring anatomy
+Spring name: `Accordion`, `AccordionHeader`
+Density variants: `compact`, `comfortable`
+States: open, closed, focus, suffix icon button
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label text** | AccordionHeader → "Icon + Text" → heading text | Semibold, primary color |
+| **Prefix icon** | AccordionHeader → leading icon (optional) | 16px icon |
+| **Suffix** | AccordionHeader → trailing area | Chevron indicator or icon button |
+| **Content items** | Accordion body → RowItem(s) | Regular text per row item |
+
+### Content rules
+- Keep labels as concise as possible. Long labels may truncate.
+- Use the label to clearly describe what the user will find when expanded.
+- Build a connection between label and description — but avoid repetition. The description should feel like an *expansion* of the label.
+
+**Example:**
+- ✅ Label: "Custom domains" → Description explains how to configure them
+- ❌ Label: "About custom domains" → Description: "Custom domains allow you to…" (repetitive)
+
+---
+
+## Buttons
+
+### Spring anatomy
+Spring name: `Button`
+Density variants: `compact`, `comfortable`
+Hierarchy: primary, secondary, tertiary
+States: default, hover, active, focus, disabled, loading
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label text** | Button → center text | Regular weight, centered |
+| **Prefix icon** | Button → leading icon (optional) | 16px icon, before label |
+| **Suffix icon** | Button → trailing icon (optional) | 16px icon, after label |
+
+### Content rules
+- **3 words maximum.**
+- No articles ("a", "the") — they waste space.
+- Describe exactly what happens on click. Avoid generic text.
+- Never describe 2 actions with "&" — that signals the workflow needs a separate step.
+- Use **"show"** instead of "view" for accessibility. Use **"go to"** if the user is navigating to a different area.
+- Use **"create"** for generating net-new resources. Use **"add"** for adding existing resources.
+- **Primary buttons** → creative or destructive actions (add, create, delete).
+- **Secondary buttons** → regressive or supportive actions (learn more, go back, cancel).
+- **"Got it"** is acceptable for strict acknowledgement. Use it instead of "ok."
+
+**Examples:**
+- ✅ "Create site" / "Delete Workspace" / "Add member"
+- ❌ "Create a new site" / "Click here to delete" / "Add & invite member"
+
+---
+
+## Badges
+
+### Spring anatomy
+Spring name: `Badge`
+Variants: color-based (e.g., default, info, success)
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label text** | Badge → text content | Short, attention-grabbing |
+
+### Content rules
+- **1 word ideal, 2 words max.** Best for concise attention-grabbing (e.g., "New").
+- Never use an "alpha" tag — alpha products are mostly internal.
+- "Beta" tags are fine for products visible to external users.
+
+**Examples:**
+- ✅ "New" / "Beta"
+- ❌ "New feature" / "Alpha release" / "Coming soon to all users"
+
+---
+
+## Banner
+
+### Spring anatomy
+Spring name: `Banner`
+Color variants: `default`, `primary` (blue), `success` (green), `warning` (yellow), `danger` (red)
+States: default, with title, with icon, with control, with status indicator, wrapping (multiline)
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label text** | Banner → primary text area | Regular weight, primary color. The main message. |
+| **Title** | Banner → title area (optional) | Semibold, appears above or inline with label |
+| **Prefix icon** | Banner → leading icon (optional) | Status/context icon |
+| **Control** | Banner → trailing area (optional) | Button or action, follows Button guidelines |
+| **Status indicator** | Banner → leading indicator (optional) | Visual signal paired with color variant |
+
+### Content rules
+- Use for urgent, critical messages or messages requiring user action.
+- **2 concise sentences max.**
+- Must communicate both the **problem** and the **solution**.
+- Buttons on banners follow standard Button guidelines.
+
+**How to distinguish from Note:** Banners are full-width, persistent bars typically anchored to the top of a page or section. Notes are inline, contained blocks that sit within content flow. If it stretches edge-to-edge and demands attention, it's a Banner. If it's an inline callout, it's a Note.
+
+**Examples:**
+- ✅ "Your site plan expires tomorrow. Update your billing to avoid interruption."
+- ❌ "Hey! Just wanted to let you know something might be wrong. You should probably check it out when you get a chance."
+
+---
+
+## Empty state & Loading state
+
+### Spring anatomy
+Spring name: `EmptyState`
+Boolean variants: `isDisabled`, `isDropTarget`
+States: text only, with link, with button, drop target, disabled
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Illustration** | EmptyState → "Icon" area (64px) | Decorative illustration, not a content slot |
+| **Heading text** | EmptyState → "content" → heading | Semibold, primary color. The key message. |
+| **Description text** | EmptyState → "content" → body | Regular weight, secondary color. Supporting detail. |
+| **CTA** | EmptyState → "controls" → Button (optional) | Follows Button guidelines |
+
+### Content rules
+
+**Empty states** (feature previously used, no data):
+- Orient users to an interface with no populated data.
+- Don't point out the obvious ("There's nothing here").
+- Direct users to take actions that will populate the state.
+- Don't need to be as guided as start states — assume the user has experience.
+
+**Loading states:**
+- Explain exactly what's happening on the backend to build trust.
+- Ellipses can connote an action currently happening (e.g., "Loading your sites …").
+
+**Start states** (first-time use):
+- More guided and helpful than empty states.
+- Avoid pointing out the obvious, but offer more guidance than a traditional empty state.
+
+**Examples:**
+- ✅ Empty: "Create a Collection to start organizing your content."
+- ❌ Empty: "You don't have any Collections yet."
+- ✅ Loading: "Setting up your Workspace …"
+- ❌ Loading: "Loading…" (too vague)
+
+---
+
+## Error messages
+
+### Spring anatomy
+Error messages can appear in multiple Spring components: `Banner` (danger variant), `Toast` (danger variant), `Note` (danger variant), or inline validation text near form fields. Identify the component first, then apply both the error content rules and that component's structural constraints.
+
+### Content rules
+- State the **problem + resolution** as concisely as possible.
+- Tell users what to do — **not what they did wrong.**
+- **Never use "please."** Write the message as a productive action.
+- Always strive to provide a resolution or helpful next step.
+- If no resolution exists, "Refresh and try again" or similar is acceptable.
+
+**Examples:**
+- ✅ "Enter a valid email address to continue."
+- ❌ "Please enter a valid email. You entered an invalid email address."
+- ✅ "Something went wrong. Refresh and try again."
+- ❌ "Error 500: An unexpected server error occurred. Please contact support."
+
+---
+
+## Form labels
+
+### Spring anatomy
+Spring name: `FormLabel`, `FormField`, `Input`
+Related components: `FormHelperText`, placeholder text
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label** | FormLabel → text above field | Persistent, visible when user types |
+| **Placeholder** | Input → ghost text inside field | Disappears on focus/input |
+| **Helper text** | FormHelperText → below field (optional) | Additional clarification |
+
+### Content rules
+- **2 words max.** Describe exactly what the user needs to input.
+- Label must remain visible above the field when the user starts typing.
+- Placeholders can provide examples but should never replace the label or convey important info.
+- Helper text goes below the field — one concise sentence for further clarification.
+
+**Examples:**
+- ✅ "Email address" (with placeholder: "name@company.com")
+- ❌ "Enter your billing email address" (too long for a label — move detail to helper text)
+
+---
+
+## Links
+
+### Spring anatomy
+Spring name: `Link`
+Color/style variants: default, primary, danger, and more
+States: default, hover, focus, disabled
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label text** | Link → text content | Single text string, typically underlined or colored |
+
+### Content rules
+- Use as secondary, text-based CTAs embedded in or after sentences.
+- Describe where the user is going as clearly as possible.
+- Links must make sense **out of context** for screen readers. Avoid generic "Learn more."
+  - If "Learn more" is necessary for space, engineering should add a descriptive `aria-label`.
+- Keep links as a brief, standalone sentence at the end of body text. Avoid mixing hyperlinks into sentences (localization concern).
+- **No period** at the end of standalone links.
+- Ideally only 1 hyperlink per piece of content. Multiple links are rare exceptions.
+- **Diagonal arrows** (↗) only when the link opens a new tab. Never use horizontal arrows in links.
+
+**Examples:**
+- ✅ "Learn more about bandwidth"
+- ❌ "Click here" / "Learn more" (without aria-label)
+
+---
+
+## List boxes
+
+### Spring anatomy
+Spring name: `ListBox`, `ListBoxItem`
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Item label** | ListBoxItem → primary text | Main selectable text |
+| **Item description** | ListBoxItem → secondary text (optional) | Supporting detail below label |
+
+### Content rules
+- Items should be concise. Ideally they don't truncate — they wrap instead.
+- All items should be the **same part of speech** (all nouns OR all verbs).
+- Descriptions should be additive to the main item, not repetitive.
+
+---
+
+## Menus
+
+### Spring anatomy
+Spring name: `Menu`, `MenuItem`
+Related: `MenuSection`, `MenuDivider`
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Item label** | MenuItem → primary text | Main clickable text |
+| **Item description** | MenuItem → secondary text (optional) | Supporting context |
+| **Prefix icon** | MenuItem → leading icon (optional) | Context icon |
+| **Suffix** | MenuItem → trailing area (optional) | Keyboard shortcut, badge, or arrow |
+
+### Content rules
+- Space-constrained — be as concise as possible.
+- Users should know exactly what happens or where they'll go on click.
+- Unlike lists, menu items do **not** all need the same part of speech.
+- **With description:** Main item 1–2 words (1 line), description within 2 lines.
+- **Without description:** Up to 2 lines.
+
+---
+
+## Modal (Dialog)
+
+### Spring anatomy
+Spring name: `Dialog` (called "Dialog" in Spring, "Modal" in content guidelines)
+Related components: `ModalMask` (backdrop overlay)
+Private sub-components: `modal-title`, `modal-header`, `modal-body`, `modal-footer`
+Variants: default/action panel, multi-path context, with/without footer, with close button + icon
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Title** | modal-header → title text | Semibold. The headline. |
+| **Icon** | modal-header → leading icon (optional) | Contextual icon before title |
+| **Close button** | modal-header → trailing X (optional) | IconButton with CloseDefault icon |
+| **Body content** | modal-body → freeform content area | Regular text. The main message area. |
+| **Footer link** | modal-footer → leading text/link (optional) | Secondary action as text |
+| **Secondary button** | modal-footer → secondary action (optional) | e.g., "Cancel", "Discard" |
+| **Primary button** | modal-footer → primary action | e.g., "Delete", "Confirm", "Save" |
+
+### Content rules
+
+**Heading:**
+- Confirmation modals: Heading can be a question.
+- Non-confirmation modals: Use declarative statements.
+- Avoid generic language like "Are you sure?" — personalize to the action.
+- No period at the end.
+
+**Body:**
+- Don't frame both heading and body as questions.
+- Confirmation body: Focus on consequences/implications of the action.
+- **3 lines max.** More text may indicate a design problem — a modal might not be the right component.
+
+**Buttons:**
+- Follow standard Button guidelines.
+- Pay extra attention to clarity — every action should be unique and clearly differentiated.
+- Avoid having both "Back" and "Cancel" next to each other.
+
+**Examples:**
+- ✅ Heading: "Delete this site?" / Body: "This will permanently remove the site and all its content. This can't be undone."
+- ❌ Heading: "Are you sure?" / Body: "Are you sure you want to delete this? It can't be undone."
+
+---
+
+## Note
+
+### Spring anatomy
+Spring name: `Note`
+Boolean variants: `isInline`, `isTinted`, `isGhost`, `isSeamless`
+Color variants: `primary`, `default`, `success`, `danger`, `warning`, `urgent`
+States: default, has close button, has control (in-line), is tinted, is ghost, is seamless, multi line, has button, has secondary button, has link, has icon
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Icon** | Note → leading icon (optional) | Contextual/status icon, 16px |
+| **Headline text** | Note → heading area | Semibold, primary color |
+| **Body text** | Note → description area | Regular weight, secondary color |
+| **Close button** | Note → trailing IconButton (optional) | Dismiss action |
+| **In-line control** | Note → trailing control (optional) | Button or link |
+| **Button** | Note → below body text (optional) | Primary or secondary action |
+| **Link** | Note → below body text (optional) | Text link CTA |
+
+### Content rules
+- **Headline** is the most important text. Clear, summarizes the key issue, suggests a possible action.
+  - For Enterprise handraisers: frame with the main user benefit.
+  - May include question marks or exclamation points. No periods unless multiple sentences.
+- **Body text:** 2 lines max.
+- **Max 2 CTAs** (including inline hyperlinks). Too many CTAs confuse users.
+
+**How to distinguish from Banner:** Notes are inline, contained blocks within content flow. Banners are full-width persistent bars. If it sits within a section as a callout, it's a Note. If it stretches across the top demanding attention, it's a Banner.
+
+**How to distinguish from Toast:** Notes are persistent and positioned inline. Toasts are transient (they auto-dismiss) and float above the UI. If the message stays, it's a Note. If it appears briefly and disappears, it's a Toast.
+
+**Spring-specific note:** `isSeamless` should only be used with `isGhost`. Secondary buttons are currently only supported for multiline notes. Links don't work as well with colored (tinted) backgrounds.
+
+---
+
+## Notifications
+
+Notifications have specialized content guidelines depending on placement. Consult the Figma file for the specific notification type you're working with.
+
+---
+
+## Onboarding Popover
+
+### Spring anatomy
+Spring name: `OnboardingPopover`
+Position variants: top, bottom, left, right (with arrow pointing to target element)
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Title** | OnboardingPopover → heading area | Semibold/bold. The feature or concept name. |
+| **Body text** | OnboardingPopover → description area | Regular weight. Explains the feature. |
+| **Image/media** | OnboardingPopover → media area (optional) | Screenshot, illustration, or video |
+| **CTA** | OnboardingPopover → action area | Link or button (e.g., "Get started", "Next", "Got it") |
+| **Close button** | OnboardingPopover → trailing X | IconButton to dismiss |
+| **Progress indicator** | OnboardingPopover → footer area (optional) | e.g., "3 of 4" for multi-step flows |
+
+### Content rules
+- Follow a logical progression — especially for multi-step onboarding flows.
+- Be as concise as possible (space-constrained).
+- If the popover contains rich elements (links, videos), ensure all accessibility needs (alt text, etc.) are addressed.
+- Progress indicators help users understand where they are in a flow — always include them for multi-step sequences.
+
+**How to distinguish from Popover:** Onboarding Popovers are specifically for onboarding/education flows — they have a distinct visual style (typically blue/branded background), progress indicators, and are part of a guided sequence. Regular Popovers are for drilling into UI details on demand.
+
+---
+
+## Popover
+
+### Spring anatomy
+Spring name: `Popover`
+Complex component with many sub-component configurations
+Position variants: top, bottom, left, right
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Title** | Popover → header area (optional) | Context for the popover content |
+| **Body content** | Popover → main content area | Flexible: text, lists, controls, inputs |
+| **Footer actions** | Popover → footer area (optional) | Buttons or links |
+
+### Content rules
+- Usually appears as a longer flow of content that helps users drill down into finer details of a UI.
+- Should always follow a logical progression.
+- Be as concise as possible (space-constrained).
+- If the popover contains rich elements (links, videos), ensure all accessibility needs (alt text, etc.) are addressed.
+
+---
+
+## Radio card
+
+### Spring anatomy
+Spring name: `RadioCard`
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Headline** | RadioCard → heading area | Semibold. The choice name. |
+| **Body text** | RadioCard → description area (optional) | Regular weight. Expands the choice. |
+| **Icon/illustration** | RadioCard → media area (optional) | Visual representation of the choice |
+
+### Content rules
+- Present mutually exclusive choices as clearly and distinctly as possible.
+- **Headlines:** Encapsulate the choice in as few words as possible. Use parallel structure (all nouns or all verbs).
+- **Body copy:** Expand nuance behind a choice. 2 sentences max.
+- If choices can't be written in parallel, concise way — consider whether a radio card is the right component.
+
+---
+
+## Switch box
+
+### Spring anatomy
+Spring name: `SwitchBox`, `Switch`
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label** | SwitchBox → text next to toggle | Describes what is being toggled |
+| **Description** | SwitchBox → secondary text (optional) | Additional context |
+
+### Content rules
+- Binary input: turns a setting on or off.
+- Label should reflect the binary nature: "on/off," "enable/disable," "turn on/turn off."
+- Surrounding content should explain what's being toggled — the switch label is too space-constrained for explanations.
+- Write content in the affirmative for clarity.
+
+---
+
+## Tabs
+
+### Spring anatomy
+Spring name: `Tabs`, `Tab`
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Tab label** | Tab → text content | Short text identifying the tab's content |
+| **Tab icon** | Tab → leading icon (optional) | Contextual icon before label |
+
+### Content rules
+- **1 word ideal, 2 words max.**
+- Label should set expectations about what appears in the tabbed area.
+- Tabs should be thematically similar to each other.
+- Ideally the **same part of speech** across all tabs (all nouns, all verbs, etc.).
+
+**Examples:**
+- ✅ "Style" / "Settings" / "Interactions"
+- ❌ "Style settings" / "Settings" / "Interactions" (inconsistent structure)
+
+---
+
+## Tables
+
+### Spring anatomy
+Spring name: `Table`, `TableRow`, `TableCell`, `TableHeader`
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Column header** | TableHeader → text | Labels the column |
+| **Row header** | First cell in row (optional) | Labels the row |
+| **Cell content** | TableCell → freeform | Data or text |
+
+### Content rules
+- Column and row labels: **2 words max.**
+- Labels should always **wrap, never truncate.** Truncation inhibits usability.
+- Labels must be declarative statements — no questions, no exclamation points.
+
+---
+
+## Tag
+
+### Spring anatomy
+Spring name: `Tag`
+Can be interactive (clickable as button or link) or static
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Label text** | Tag → text content | Metadata label |
+| **Prefix icon** | Tag → leading icon (optional) | Contextual icon |
+| **Dismiss button** | Tag → trailing X (optional) | Removes the tag |
+
+### Content rules
+- Metadata elements — concise and descriptive.
+- **1 word ideal, 2 words max.**
+- Tags can be clickable (as button or link). When clickable, also follow Button/Link guidelines.
+- **Tag vs. Badge:**
+  - Badge = highlights new or altered features. Not selectable or interactive (can have tooltip).
+  - Tag = labels, categorizes, or organizes items with keywords. Can be dismissible.
+
+---
+
+## Toast
+
+### Spring anatomy
+Spring name: `Toast`
+Boolean variants: `isInline` (floating vs. embedded)
+Color variants: `default`, `primary` (blue), `success` (green), `danger` (red), `warning` (yellow)
+States: default, without icon, multiline, with control
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Icon** | Toast → leading icon (optional, toggle: `hasIcon`) | Status/context icon, 16px |
+| **Title** | Toast → heading text (optional, toggle: `hasTitle`) | Semibold, primary color |
+| **Body text** | Toast → description text (always present) | Regular weight, secondary color |
+| **CTA Button** | Toast → action button (optional, toggle: `hasControl`) | Follows Button guidelines |
+| **Close button** | Toast → trailing IconButton | CloseDefault icon to dismiss |
+
+### Content rules
+- Transient messages — **conciseness is key.** Never so long they truncate.
+- Can contain 1 optional CTA for a logical next step.
+- Can be styled with or without a heading.
+- **Drop unnecessary fluff.** Classic example: "successfully" is redundant when paired with strong verbiage and a green background.
+
+**How to distinguish from Note:** Toasts are transient — they float above the UI and auto-dismiss. Notes are persistent inline blocks. If it disappears on its own, it's a Toast.
+
+**How to distinguish from Banner:** Toasts float in a corner or edge of the viewport. Banners are anchored full-width bars. If it's a floating notification, it's a Toast.
+
+**Examples:**
+- ✅ "Site published" / "Changes saved"
+- ❌ "Your site has been successfully published!" / "Your changes have been saved successfully."
+
+---
+
+## Tooltip
+
+### Spring anatomy
+Spring name: `Tooltip`
+Position variants: top, bottom, left, right (with arrow pointing to trigger element)
+
+| Slot | Location | Type |
+|------|----------|------|
+| **Title** | Tooltip → heading text (optional) | Bold/semibold. Short label. |
+| **Description** | Tooltip → body text | Regular weight. The main helper text. |
+| **Slot content** | Tooltip → custom content area (optional) | Can contain breadcrumbs or other structured content |
+
+### Content rules
+- Ancillary, helpful information about a UI element.
+- **~2 lines recommended.** Can be longer if necessary, but keep it tight.
+- Assume tooltip content may never be read — or only by attentive power users. Use that to decide what belongs in the tooltip vs. core UI.
+- **No interactive elements** (links, buttons) per WCAG 2.0.
+- Overly lengthy tooltips often signal the core UI isn't self-explanatory. If you observe this, scrutinize the design.
+
+---
+
+## Upsell banner
+
+### Spring anatomy
+Upsell banners are visually designed versions of `Note` components. They follow the same Spring anatomy as Note but with brand-specific styling.
+
+### Content rules
+- Follow all content guidelines under **Note** — upsell banners are more specific, visually designed versions of notes.
+
+---
+
+## Component identification guide
+
+When looking at a Figma prototype, use these distinguishing characteristics to identify the right component:
+
+| If you see... | It's likely a... |
+|---------------|-----------------|
+| Full-width bar anchored to top of page/section | **Banner** |
+| Inline callout box within content flow | **Note** |
+| Floating notification that auto-dismisses | **Toast** |
+| Overlay dialog with backdrop mask | **Modal (Dialog)** |
+| Small text bubble on hover near a UI element | **Tooltip** |
+| Branded blue card with progress indicator (e.g., "2 of 4") | **Onboarding Popover** |
+| Dropdown-style panel for drilling into details | **Popover** |
+| Centered illustration + heading + CTA in an empty area | **Empty state** |
+| Mutually exclusive cards arranged side-by-side | **Radio card** |
+| Toggle with a label | **Switch box** |
+| Horizontal row of short labels switching content below | **Tabs** |
+| Short colored pill/chip on or near a UI element | **Badge** (if static) or **Tag** (if interactive/dismissible) |

--- a/plugins/webflow-skills/skills/webflow-content-design/references/content-checklist.md
+++ b/plugins/webflow-skills/skills/webflow-content-design/references/content-checklist.md
@@ -1,0 +1,103 @@
+# Content Audit Checklist
+
+Use this checklist when auditing existing copy. Check each applicable item and note any violations in your changelog.
+
+---
+
+## Overall Best Practices
+
+- [ ] **Conversational** — Contractions used? Simplest/shortest words? "You" for the user? ~6th grade reading level?
+- [ ] **Concise but clear** — Headlines and instructions as short as possible? No repetition, redundancy, ambiguity, or unnecessary words? (But not short at the expense of clarity.)
+- [ ] **Accessible** — Complex features/terms explained in plain language? Tooltips focused on the JTBD?
+- [ ] **Universal** — No idioms or hard-to-translate phrases?
+- [ ] **Consistent** — Parallel patterns and style across same-type components?
+- [ ] **Logical** — Clear narrative progression across screens?
+- [ ] **Guiding** — Next required action clearly stated?
+- [ ] **User-focused** — User benefits emphasized over Webflow goals?
+- [ ] **Holistic** — Text complements visual layout?
+- [ ] **Prioritized** — Information hierarchy clear? Most important actions stand out?
+- [ ] **Sentence cased** — Everything in sentence case? Only proper nouns and product names capitalized?
+- [ ] **Straightforward** — Active voice used? (Passive only to avoid blaming user.)
+
+---
+
+## Voice, Tone & Terminology
+
+- [ ] **Empathetic** — Tone upbeat and appropriate for context and user state of mind?
+- [ ] **On-brand** — Grammar, terminology, phrasing, and formality align with Webflow voice principles?
+- [ ] **Consistent** — Terminology consistent across the entire user experience?
+- [ ] **Universal** — Any humor is culturally appropriate and universally relevant?
+- [ ] **Reliable** — Speaker POV consistent throughout? No POV switches?
+- [ ] **Correct** — Spelling, grammar, capitalization, date/number formats checked?
+
+---
+
+## Error Messages
+
+- [ ] **Actionable** — Says what happened and what to do to get back on task?
+- [ ] **Compassionate** — Tone matches severity? Doesn't blame the user?
+- [ ] **Proximal** — Error message close to the relevant field/component?
+
+---
+
+## Tooltips & Instructional Text
+
+- [ ] **Informative** — Enough info at every point to make a decision and continue?
+- [ ] **Prepared** — Enough context about consequences before multi-step tasks or critical actions?
+- [ ] **Reassuring** — Complex decision points addressed with reassuring guidance?
+- [ ] **Generous** — Tooltips provide extra details for anxious users?
+- [ ] **Supportive** — Progressive disclosure used? No dead ends?
+
+---
+
+## Notifications & Alerts
+
+- [ ] **Front-loaded** — Clear even if truncated? Most important words first?
+- [ ] **Meaningful** — Useful and relevant at the moment they appear?
+- [ ] **Appropriate** — Tone appropriate to user context?
+- [ ] **User-focused** — Prioritized by user needs, not team needs?
+- [ ] **Consistent** — Conforms to framework for similar message types?
+
+---
+
+## Onboarding (First-Use)
+
+- [ ] **Value-oriented** — Shows how to experience value ASAP?
+- [ ] **User-focused** — Benefits over features/technical details?
+- [ ] **Cohesive** — Matches marketing selling points?
+- [ ] **Necessary** — Only essential info for first-time users?
+- [ ] **Reassuring** — Answers pressing questions and removes doubt?
+- [ ] **Respectful** — Explains reasons before asking for permissions/data?
+
+---
+
+## Dialogs/Modals
+
+- [ ] **Direct** — Headline asks one clear question or communicates one message?
+- [ ] **Distinct** — Primary button states unambiguous action?
+- [ ] **Explanatory** — Body clarifies consequences in simple terms?
+
+---
+
+## Empty States
+
+- [ ] **Positive** — Focuses on user benefit?
+- [ ] **Explicit** — Clear what action fills the empty state?
+- [ ] **Indicative** — Gives indication of what will occupy the space?
+
+---
+
+## Quick Grammar Checks
+
+- [ ] Oxford comma in all lists of 3+?
+- [ ] No semicolons?
+- [ ] No ampersands in body copy?
+- [ ] Numerals (not number words)?
+- [ ] Em dashes with spaces on each side?
+- [ ] Ellipses with spaces on each side?
+- [ ] Periods on full sentences (including tooltips/toasts)?
+- [ ] No periods on headings, short phrases, buttons?
+- [ ] Contractions where natural (can't, don't, you're)?
+- [ ] No "please" in error messages (unless severe)?
+- [ ] No "sorry" in error messages (unless severe and irreparable)?
+- [ ] Product terms capitalized correctly? (Check terminology.md)

--- a/plugins/webflow-skills/skills/webflow-content-design/references/content-patterns.md
+++ b/plugins/webflow-skills/skills/webflow-content-design/references/content-patterns.md
@@ -1,0 +1,227 @@
+# Content Patterns by Type
+
+## Table of Contents
+1. In-Product UI Copy
+2. SYBG Modal Content
+3. webflow.com/updates Posts
+4. Help Documentation / University Articles
+
+---
+
+## 1. In-Product UI Copy
+
+### General Principles
+- Conversational: use contractions, simplest/shortest word, "you" to address the user, ~6th grade reading level
+- Concise but clear: short + confusing helps no one, so go longer if it's useful
+- Accessible: explain complex features in plain language the first time they appear
+- Universal: avoid idioms and hard-to-translate phrases
+- Sentence case everywhere
+- Active voice (passive only to avoid blaming the user)
+
+### By Component
+
+#### Buttons and CTAs
+- 1-2 words preferred
+- Use imperative verbs: "Save," "Remove," "Create" — not "Okay" or "Submit"
+- Sentence case
+- Include an option to dismiss or cancel so users can opt out
+
+#### Tooltips
+- Focus on the most important info the user needs to achieve their goal
+- Be clear about the job to be done (JTBD)
+- Full sentences get periods
+- Don't shy away from industry jargon — but explain it in plain language
+
+#### Error Messages
+Structure: What happened → Why → What to do next
+
+**Title:**
+- Sentence case, ~3-4 words
+- Communicate the result of the error
+- Be informative and scannable
+- Don't explain what to do (save that for body)
+- Don't ask questions
+- Example: "That page doesn't exist" not "Invalid"
+
+**Body:**
+- 1-2 sentences
+- Don't repeat the title
+- Include: reason for error + what to do next + consequences of inaction
+- Use "Learn more" link for anything over 2 sentences
+- Example: "The template you chose has been removed — return to Marketplace to choose a new one."
+
+**Tone guidance:**
+- Avoid "please" — can undermine authority and make required steps seem optional
+- Avoid "sorry" — can make errors feel more severe than they are (only apologize for severe, irreparable consequences)
+- Use "we" instead of "you" to avoid blaming: "We lost the connection" not "Something's wrong with your connection"
+- When multiple solutions exist: simplest solution first, alternative in second sentence
+
+#### Empty States
+- Focus on user benefit and encourage progress toward a goal
+- Make it clear exactly what action fills the empty state
+- Give an indication of what data/content will eventually appear there
+
+#### Dialogs/Modals
+- Headline: single clear question or single concise message
+- Primary button: unambiguous action that indicates what happens on click
+- Body: clarify consequences and explain options in simple terms
+
+#### Onboarding (First-Use)
+- Show users how to experience value ASAP
+- Focus on user benefits, not features or technical details
+- Match selling points from marketing
+- Convey only essential info needed to inspire action
+- Answer the user's most pressing questions and remove doubt
+- Explain why before asking for permissions or data access
+
+#### Notifications and Alerts
+- Front-load: most important words first (in case of truncation)
+- Start with user benefit, not work required
+- Match tone to user context
+- Prioritize user needs over sales/marketing/product team needs
+
+#### Dashboards
+- Clear visual emphasis on important stats and recommended actions
+- Logically grouped and labeled data
+- Tooltips or links to help articles for complex terms
+- Clear which actions are mandatory, recommended, or optional
+
+#### Forms
+- Group similar fields into sections
+- Clear, consistent labels in plain language
+- Field labels and helper text serve separate purposes (no redundancy)
+- Helper text prevents errors with examples or formatting instructions
+- Tooltips for fields where users need reassurance
+
+#### Transactional Emails
+- Subject line: ~40 characters, required action/urgency clear
+- Front-load: most important idea or action obvious from heading
+- Body: short, scannable, useful subheadings
+- CTA easy to find, near top
+- Tone: respectful, positive, solution-oriented
+- Tell users how to get more info or contact support
+
+---
+
+## 2. SYBG Modal Content
+
+The SYBG ("Since You've Been Gone") modal appears on the Webflow Dashboard when users log in. It highlights new features and updates they may have missed. Content is managed through Knock Guides.
+
+### Fields to Write
+
+| Field | What to Write | Guidelines |
+|-------|--------------|------------|
+| **Full Title** | The release/feature name | Sentence case. Clear, scannable. Should make sense as a standalone headline. |
+| **Condensed Title** | Same as Full Title | Keep identical to Full Title for consistency. |
+| **Image Alt Text** | Short description of the image | For accessibility. Describe what's shown, not what it means. |
+| **Content** | Description of the release | 2-3 sentences. What it is, why it matters to the user, what they can do with it. Empowering and user-centered. |
+| **Primary Button Text** | Usually "Learn more" | Keep as "Learn more" unless there's a more specific action. |
+| **Primary Button URL** | Link to /updates page | Use full URL with https://www. |
+
+### Writing Tips for SYBG
+- Lead with the user benefit, not the feature name
+- Be specific about what changed — vague announcements don't build trust
+- Match the celebratory but grounded tone: exciting, not hype-y
+- Keep the Content field tight — users are scanning, not reading deeply
+- The modal shows multiple features in a list, so each entry competes for attention. Make yours count in 2-3 sentences.
+
+### Example Structure for Content Field
+"[What it does in one sentence — focused on user benefit]. [How it works or what's new, briefly]. [Where to find it or what to do next — optional]."
+
+---
+
+## 3. webflow.com/updates Posts
+
+These are public-facing release announcements. They should be polished, on-brand, and serve both existing users (who want to know what changed) and prospective users (who are evaluating Webflow).
+
+### Recommended Structure
+
+**Title**
+- Feature or update name, sentence case
+- Clear and descriptive — searchable and scannable
+
+**Hero Visual**
+- Screenshot, GIF, or illustration showing the feature in action
+
+**Intro Paragraph (2-3 sentences)**
+- What this update is and why it matters
+- Lead with user benefit
+- Set context for who this helps
+
+**What's New Section**
+- Walk through the key changes or capabilities
+- Use short paragraphs (2-3 sentences each)
+- Use headings to break up sections if there are multiple sub-features
+- Include visuals (screenshots or GIFs) to show, not just tell
+
+**How to Use It**
+- Brief instructions or pointers to get started
+- Use breadcrumbs for navigation: "Open Project settings > Hosting > 301 redirects"
+- Link to relevant University articles for deeper guidance
+
+**CTA**
+- Clear next step: "Try it now," "Learn more in Webflow University," etc.
+- Link to the relevant product surface or help article
+
+### Tone for /updates
+- Celebratory but grounded — the Bold dimension dialed up slightly
+- Empowering: center what the user can now do, not what Webflow built
+- Specific: "You can now set breakpoints on individual elements" not "We've improved the design experience"
+- Professional but warm — these posts represent Webflow to the world
+
+### Length
+- Aim for 300-600 words depending on complexity
+- Simple feature: shorter, punchier
+- Major release: longer, more detailed, possibly with sub-sections
+
+---
+
+## 4. Help Documentation / University Articles
+
+### General Principles
+- Write as if speaking with someone, not at them
+- Imagine the reader sitting next to you as you walk them through the Webflow interface
+- Users are likely intimidated — write with empathy and patience
+- Use the shortest, most common words
+- Read your writing aloud — if it doesn't sound natural, change it
+
+### Article Structure
+
+**Title**
+- Guides (general feature descriptions): use the feature name — "Sliders" not "Learn about sliders"
+- Tutorials (walkthroughs): [Verb] + [result] + [feature/tech] — "Build a pricing grid with Flexbox"
+- Never include "how to" or "Webflow" in titles
+- Never phrase as questions
+- Never use first person
+
+**Body structure:**
+1. Clear title
+2. Companion video embed (if exists)
+3. Brief subtitle/explanation
+4. Intro text (sometimes not necessary)
+5. Numbered outline of the lesson (acts as table of contents)
+6. Lesson body with H2s matching the outline
+
+### Writing Rules
+- **Sentence case** everywhere
+- **Breadcrumbs** for navigation steps: "Open Project settings > Hosting > 301 redirects"
+- **Descriptive headings** that help skim/scan
+- **Short sections** — break up dense paragraphs
+- **Short sentences** — one idea per sentence
+- **Present tense** — more direct and easier to understand
+- **Contractions** where natural
+- **Active voice** — "Update your SEO setting in the Pages panel"
+- **Address readers directly** with "you"
+- **Numerals** — "Enter two 3s" / "Add 3 rows"
+- **Bold** UI elements, menu names, tab names, command names
+- **Lists** to simplify complex material
+- **Callouts** for important info: Note: / Good to know: (blue) / Important: (orange)
+- **Links** embedded in descriptive text, never "click here" or "learn more" alone
+- External links open in new tab
+
+### Visuals
+- Use to clarify complex UI descriptions
+- Skip if instructions are standard and text suffices
+- Screenshots for static UI callouts
+- GIFs sparingly for multi-step sequences
+- Always include alt text

--- a/plugins/webflow-skills/skills/webflow-content-design/references/grammar-mechanics.md
+++ b/plugins/webflow-skills/skills/webflow-content-design/references/grammar-mechanics.md
@@ -1,0 +1,226 @@
+# Grammar & Mechanics Reference
+
+## Table of Contents
+1. AP Style
+2. Active vs. Passive Voice
+3. Contractions
+4. Capitalization
+5. Pronouns
+6. Verb Tenses
+7. Punctuation
+8. Abbreviations
+9. Numbers
+10. Lists
+
+---
+
+## 1. AP Style
+
+Webflow uses Associated Press (AP) style for in-product writing. When in doubt, check AP guidelines.
+
+---
+
+## 2. Active vs. Passive Voice
+
+Use active voice by default. Switch to passive to soften a message or avoid blaming the user.
+
+**Active (default):**
+- YES: "You can update your payment info under the billing tab."
+- NO: "Payment info can be updated under the billing tab."
+
+**Passive (to soften):**
+- YES: "Your payment was declined."
+- NO: "We declined your payment."
+- YES: "Your bill wasn't paid."
+- NO: "You didn't pay your bill."
+
+---
+
+## 3. Contractions
+
+Use contractions for a conversational tone. Avoid contractions that sound awkward or outdated.
+
+**Use:** Can't, Don't, You're, Doesn't, Shouldn't, It's, Couldn't, I'm, Hasn't, Haven't, You've
+
+**Avoid:** That'll, Would've, This'll, There're, Mustn't, Needn't, Who've, Gotta, It'd, Ain't, Ya'll
+
+---
+
+## 4. Capitalization
+
+Webflow uses **sentence case everywhere** — lowercase everything unless it:
+- Starts a sentence
+- Starts a heading
+- Starts a CTA
+- Is a proper noun or product name
+
+**Team names:** Capitalize the team name, lowercase "team" — e.g., Support team, Content team.
+
+**YES:** "This is sentence case"
+**NO:** "This Is Title Case"
+
+See `terminology.md` for specific product/feature capitalization.
+
+---
+
+## 5. Pronouns
+
+### Second person (you/your) — Use in most situations
+- YES: "You can update your billing information on the settings page."
+- NO: "I can update my billing information on the settings page."
+
+### First person (I/me/my) — Only when:
+- Users are answering a direct question
+- Sensitivity or privacy are important
+- Legal requires consent
+- YES: "I agree to these terms of service."
+- NO: "You agree to these terms of service."
+
+### "They" — Use for inclusive, gender-neutral language
+- YES: "Amrita accepted your invite — assign them a role."
+- NO: "Amrita accepted your invite — assign him/her a role."
+
+### "We" — Generally avoid in interface copy
+Use "we" only if:
+- Users are waiting for a response from us
+- An error message needs to clarify who needs to take action
+- YES: "We'll review your request and get back to you within 2 business days."
+- YES: "We lost the connection. Try refreshing the page."
+- NO: "We heard your feedback and now you can do all these awesome things."
+- NO: "We'll get your billing info updated." (Use: "Update your billing info from the Settings tab.")
+
+---
+
+## 6. Verb Tenses
+
+Use simple verb tenses — past, present, future — to keep things concise and scannable.
+
+- YES: "You upgraded your Site plan." / NO: "You're upgrading your Site plan."
+- YES: "You can't undo this action." / NO: "You're not undoing this action."
+- YES: "Your credit card will be charged at the end of the month." / NO: "Your credit card will have been charged at the end of the month."
+
+---
+
+## 7. Punctuation
+
+### Ampersand (&)
+Avoid in body copy. Optional in links, buttons, and headings to reduce character count.
+
+### Apostrophe
+Don't use in place of quotation marks.
+
+### At sign (@)
+Don't replace the word "at" with @.
+
+### Brackets/Parentheses
+Avoid [] in product copy. Use () sparingly. Em dashes are often less visually noisy.
+- If parenthetical is part of a sentence, period goes after closing parenthesis.
+- (If parenthetical is its own sentence, period goes before closing parenthesis.)
+
+### Comma (Oxford comma)
+Always use the serial comma in lists of 3+ items.
+- YES: "Save your file as a JPEG, PNG, or GIF."
+- NO: "Save your file as a JPEG, PNG or GIF."
+
+If a sentence has 3+ commas or wordy items, consider a bulleted list.
+
+### Ellipsis (...)
+Include a space before and after.
+- YES: "Your Collection list is saving …"
+- NO: "Your Collection list is saving…"
+
+### Em dash (—)
+Use with a space on each side for an aside or dramatic pause.
+- "Drag, drop, design — and let Webflow take care of the code."
+- Make: Option + Shift + Hyphen (Mac), or &mdash; in HTML
+
+### En dash (–)
+Use with no spaces in a range (times, dates).
+- "12pm–2pm, April 12–13"
+- Make: Option + Hyphen (Mac), or &ndash; in HTML
+
+### Hyphen (-)
+Between hyphenated words, no spaces.
+- "View-only mode"
+
+### Exclamation point
+Use sparingly. Only exclaim about things users are likely excited about. Difficult to localize.
+
+### Percent
+Use the symbol (%) instead of spelling out the word.
+
+### Period
+Full sentences get periods — yes, even on tooltips and toasts.
+- One space after a period, never two.
+- No periods at the end of: headings (unless multiple sentences), short phrases, buttons, bulleted lists (unless one item needs a period, then use on all).
+
+### Question mark
+Avoid on alert headings or rhetorical questions.
+- YES: "Delete template"
+- NO: "Delete template?"
+
+### Quotation marks
+Use double quotes ("") for quoting text or referring to file/asset names.
+- Place punctuation inside quotation marks — unless referring to typed commands.
+- YES: Avoid words like "all," "every," or "most."
+- YES: To remove this Collection list, type "DELETE".
+
+### Semicolon
+Avoid. Use periods, commas, or em dashes instead.
+
+### Slash
+Use "and" or "or" instead.
+
+---
+
+## 8. Abbreviations
+
+### Amounts
+Capitalized, no periods: K (thousands), M (millions), B (billions)
+
+### Measurements
+Use AP style abbreviations. Spell out in full sentences. Space between number and unit (e.g., 2 px, 3 MB).
+
+### Months
+First 3 letters, no periods: Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec
+
+### Days
+First 3 letters, no periods: Sun, Mon, Tue, Wed, Thu, Fri, Sat
+
+### Time
+Space between number and unit, no period, no comma: Sec, Min, Hr
+- E.g., "3 hr 42 min"
+- Lowercase am/pm without space: 3pm (unless using 24-hour clock: 16:30)
+
+---
+
+## 9. Numbers
+
+### Currency
+Use number form without decimal unless cents are involved.
+- YES: "$10 will be returned to your card."
+- NO: "$10.00 will be returned to your card."
+- YES: "You'll be charged $35.60 on the 5th of every month."
+- Use international abbreviations: 100 CAD
+
+### Large numbers
+Comma-separate groups of 3 digits: 1,000 / 10,000 / 100,000 / 1,000,000
+
+### Numerals
+Always use numerals instead of number words.
+- YES: "You have 3 member seats available."
+- NO: "You have three member seats available."
+
+---
+
+## 10. Lists
+
+- Use numbered lists for sequential steps
+- Use bulleted lists when sequence doesn't matter
+- Introduce with a colon or heading
+- Capitalize the first letter of each item
+- Use parallel construction (same word type, tense, voice, sentence type)
+
+**Parallel example:**
+- YES: Designer / Editor / Viewer
+- NO: Being the Designer / Editor / And a Viewer

--- a/plugins/webflow-skills/skills/webflow-content-design/references/terminology.md
+++ b/plugins/webflow-skills/skills/webflow-content-design/references/terminology.md
@@ -1,0 +1,169 @@
+# A-Z Terminology Reference
+
+Definitive capitalization and usage rules for product terms. Consult this list when writing or reviewing copy.
+
+## Table of contents
+- [A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g)
+- [I](#i) | [L](#l) | [M](#m) | [O](#o) | [P](#p) | [Q](#q) | [S](#s)
+- [T](#t) | [V](#v) | [W](#w)
+
+---
+
+## A
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| access groups | lowercase | Controls which Memberships users can access content. Free and paid groups. |
+| account settings | lowercase | Profile, subscriptions, billing info, and other account-specific settings. |
+| action | lowercase | Accepts input data, executes logic, provides output data. |
+| action block | lowercase | An event performed after a flow starts in Logic. |
+| Agency or Freelancer Guest | uppercase (full feature name) | Lowercase when referring to freelancers/agencies as people. E.g., "The guest role is perfect for freelancers and agencies." |
+| Apps | uppercase | Two meanings: (1) Community-built applications available on Marketplace. (2) A project type for building applications (alongside sites and Campaigns). Context determines which. |
+
+## B
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| block | lowercase | A unit used for building a flow in Logic. |
+| Bold text | n/a | Use bold in interface copy and help docs to indicate where to click or what to select. Match casing to what the user sees in the interface. |
+
+## C
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| CMS | all caps | Always. |
+| Campaigns | uppercase | A project type for building marketing campaigns (alongside sites and Apps). |
+| Collection | uppercase "Collection" | Lowercase the word after it: Collection page, Collection list, Collection item, Collection limits. Exception: Collection URL (uppercase URL). |
+| components | lowercase | Rebranding of Symbols. Reusable and customizable UI blocks. |
+| condition | lowercase | Logic that decides the course of an action. |
+| conditional rule | lowercase | A Logic block that enables different actions based on true/false. |
+| connection point | lowercase | Where a block can be added in Logic. |
+| Content editor (role) | mixed | Uppercase "Content," lowercase "editor." Makes content edits in the Designer. |
+| creator profiles | lowercase | Profiles for creators on Marketplace. |
+| creators | lowercase | Community members that create templates, libraries, MiW sites, etc. |
+
+## D
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| Designer (app) | uppercase | The main interface to build sites. |
+| DevLink | PascalCase | Uppercase both words, one word. "Learn more about DevLink." |
+
+## E
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| e.g., | lowercase | Add a comma after the second period. Always use periods — screen readers read "eg" as "egg." |
+| Ecommerce | uppercase | When referring to the product. One word. |
+| Editor | uppercase | The simplified interface used by Content editors. |
+| Enterprise | uppercase | Customers with specialized enterprise pricing packages. |
+| events | lowercase | E.g., "events" in lowercase. |
+| Experts | uppercase | Top agencies and freelancers. |
+| Experts directory | mixed | Uppercase "Experts," lowercase "directory." Same pattern for "Expert profile" and "Expert matchmaking tool." |
+
+## F
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| flow | lowercase | A sequence in Logic using triggers, actions, and data. |
+| folder | lowercase | Container where sites can be grouped to organize a Workspace. |
+| full CMS access | lowercase | Formerly "advanced staging." |
+
+## G
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| guest | lowercase (usually) | Uppercase only in the full feature name "Agency or Freelancer Guest." |
+
+## I
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| Italics | n/a | Use to add emphasis or refer to artworks. Poems, songs, and article titles go in quotation marks. |
+
+## L
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| Libraries | uppercase | Collections of reusable building blocks. Includes Local Libraries, Workspace Libraries, Starter Libraries, Marketplace Libraries. |
+| Logic | uppercase | Automated workflows. |
+
+## M
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| Made in Webflow | mixed | Uppercase "Made" and "Webflow," lowercase "in." Sites are featured *on* Made in Webflow. "Showcase" can still be used as a verb. |
+| Marketplace | uppercase | Find Apps, Libraries, Templates, Inspiration, and Agencies. |
+| member(s) | lowercase | Spots available on a Workspace plan. "Invite members." |
+| Memberships | uppercase | Feature for adding users, login, and access groups to sites. |
+| mode | lowercase | Specific level of permissions for different roles. |
+
+## O
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| overrides | lowercase | |
+
+## P
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| page branching | lowercase | Lets multiple designers work on different pages on the same site simultaneously. |
+| permissions | lowercase | A set of operations someone can do inside a specific role. |
+| project | lowercase | The umbrella term for things users build. Three types: sites, Apps, and Campaigns. Use "project" when referring generally; use the specific type when referring to a particular kind. |
+
+## Q
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| Quotation marks | n/a | Use double quotes for all quotes. Single quotes for nested quotes or conveying a thought. Place punctuation inside quotation marks unless referring to typed commands. |
+
+## S
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| site | lowercase | A type of project — specifically for building websites. One of three project types alongside Apps and Campaigns. |
+| site activity log | lowercase | Enterprise feature logging design changes. |
+| Site admin (role) | mixed | Uppercase "Site," lowercase "admin." Full access to content, can add/edit/publish/transfer sites. |
+| Site designer (role) | mixed | Uppercase "Site," lowercase "designer." Can design, not publish. |
+| Site plan | mixed | Uppercase "Site," lowercase "plan." Adds features/functionality including hosting. |
+| Site publisher (role) | mixed | Uppercase "Site," lowercase "publisher." Has access to publish and design. |
+| site-specific access | lowercase, hyphenated | Controls which sites guests can access. |
+| Staff account (role) | mixed | Uppercase "Staff," lowercase "account." A Content editor on Ecommerce. |
+| starter site | lowercase | A site with limited functionality that can only be published to webflow.io. |
+| symbols | lowercase | Elements and child elements turned into reusable components. |
+
+## T
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| Templates | uppercase | Free and paid Template sites approved through submission guidelines (not MiW sites). |
+
+## V
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| view-only (mode) | lowercase | A subset of Designer permissions for previewing a site. |
+| Viewer (role) | uppercase | Can view a site and leave feedback. |
+
+## W
+
+| Term | Capitalization | Notes |
+|------|---------------|-------|
+| Workspace(s) | uppercase | Holds and accesses sites, members, settings, and integrations. |
+| Workspace admin (role) | mixed | Uppercase "Workspace," lowercase "admin." Can view/edit all sites, manage users and billing. |
+| Workspace plan | mixed | Uppercase "Workspace," lowercase "plan." |
+| Workspace owner (role) | mixed | Uppercase "Workspace," lowercase "owner." Most powerful role with full access. |
+
+---
+
+## Team name convention
+Capitalize the team name, lowercase "team": Support team, Content team, Marketing team.
+
+## Important: Deprecated terms
+- **"Unhosted site"** → Use "starter site" instead.
+- **"Showcase"** → The noun is now "Made in Webflow." "Showcase" can still be used as a verb.
+- **"Symbols"** → Rebranded to "components," but "symbols" is still recognized.
+
+## Important: Reinstated terms
+- **"Project"** — Previously archived, now reinstated as the umbrella term for things users build. Three types: **sites** (existing), **Apps** (new), and **Campaigns** (new). Use "project" when referring generally; use the specific type when referring to a particular kind.

--- a/plugins/webflow-skills/skills/webflow-content-design/references/voice-and-tone.md
+++ b/plugins/webflow-skills/skills/webflow-content-design/references/voice-and-tone.md
@@ -1,0 +1,111 @@
+# Voice and Tone Reference
+
+## Table of Contents
+1. Voice Dimensions
+2. Voice vs. Tone
+3. Tone Shifting by Context
+4. Webflow Boilerplate
+
+---
+
+## 1. Voice Dimensions
+
+Webflow's voice is rooted in the brand personality: **the wise mentor.** It stays consistent across every surface. There are four dimensions.
+
+### Knowledgeable
+*Corresponding brand principle: Unmistakably pro*
+
+We speak with confidence backed by deep knowledge about web design and development — but we're never condescending, overly academic, or know-it-all. We speak the language of our pro audience to build trust, but we never overdo it with unnecessary jargon.
+
+**Do:**
+- Confidently share knowledge and expertise in empowering ways
+- Meet the pro audience where they are by speaking their language
+
+**Don't:**
+- Be condescending
+- Overdo it with jargon or be overly academic
+
+**Show it off:** When talking about the power the product brings to professionals and teams.
+
+### Empowering
+*Corresponding brand principle: Empowering*
+
+We're uplifting and motivational. We center our customers — not ourselves — when we speak. We believe our customers are capable of great things and seek to instill confidence in them. We don't ignore the complexities of our product. We're optimistic about technology, not fear-mongering.
+
+**Do:**
+- Communicate in uplifting, optimistic ways that center the customer
+- Center and empower the customer
+
+**Don't:**
+- Ignore the complexities of building for the web or using Webflow
+- Be negative about those complexities
+
+**Show it off:** When talking about what the product can do for professionals and teams.
+
+### Down-to-earth
+*No specific brand principle — this applies everywhere.*
+
+We speak like a real person — a kind, approachable one. We don't overpromise, use complicated metaphors, or use lofty language. We say more with less, focusing on real-world solutions and outcomes. We never trade substance for humor, but a well-placed wink is worth a thousand words. Professional but not dry or intimidating. We respect that our audience's time and attention are valuable.
+
+**Do:**
+- Focus on real solutions and empowering outcomes
+- Use well-placed winks of humor
+- Default to straightforward language
+
+**Don't:**
+- Trade substance for humor or colloquialisms
+- Use complicated metaphors or grandiose language
+
+**Show it off:** All the time. Always communicate in approachable, kind, and inclusive ways.
+
+### Bold
+*Corresponding brand principle: Bold*
+
+We fearlessly embrace the power of technology to make the world better, but we're not brash or careless. We're intentional about when to dial it up and turn heads — and when to be more subtle. Bold only when we can back it up.
+
+**Do:**
+- Back up bold claims with showing, not just telling
+- Be choosy about when to be bold
+
+**Don't:**
+- Overdo it — boldness is a bubble over, not a constant boil
+
+**Show it off:** When showcasing a particularly cool product capability or turning heads in a brand campaign.
+
+---
+
+## 2. Voice vs. Tone
+
+**Voice** = personality. Stays the same situation to situation, like a person's core personality.
+
+**Tone** = the situational adjustment. Same person at a wedding vs. a funeral — same personality, very different tone.
+
+---
+
+## 3. Tone Shifting by Context
+
+| Context | Tone Guidance |
+|---------|--------------|
+| New feature launch (SYBG, /updates) | Celebratory, empowering, bold where earned. Center the user benefit. |
+| In-product UI (general) | Clear, helpful, down-to-earth. Get out of the way. |
+| Error messages | Calm, supportive, solution-oriented. Never blame the user. |
+| Onboarding | Warm, encouraging, confidence-building. Reduce anxiety. |
+| Empty states | Positive, action-oriented. Focus on what they can do. |
+| Tooltips | Informative, concise. Focus on the job to be done. |
+| Help documentation | Patient, clear, empathetic. Imagine the reader sitting next to you. |
+| Upgrade/pricing | Honest, value-focused. Never pushy or fear-driven. |
+| Destructive actions | Clear, calm, informative about consequences. No drama. |
+
+---
+
+## 4. Webflow Boilerplate
+
+**In a sentence:**
+Webflow is a Website Experience Platform (WXP) that empowers cross-functional teams of marketers, designers, and developers to visually build, manage, and optimize stunning websites with AI-driven personalization and a powerful composable CMS, enabling businesses to drive real, measurable results.
+
+**In a few sentences:**
+Webflow is a Website Experience Platform (WXP) that empowers marketers, designers, and developers to visually build, manage, and optimize stunning websites that deliver enterprise-grade performance and AI-driven personalized experiences.
+
+Unlike traditional platforms that create siloes between teams, Webflow's Website Experience Platform (WXP) brings marketers, designers, and developers together in a shared environment — equipping each with the tools they need to collaborate, execute at scale, and drive results through visual, composable CMS and AI-powered optimization.
+
+Today, over 300,000 of the best companies in the world — from The New York Times, Dropbox, Monday.com, TED, Orangetheory Fitness, and Checkout.com — use Webflow to build, manage, and optimize their websites.


### PR DESCRIPTION
Adds ALOOP-87’s first general-purpose workflow skills to Webflow Skills, where they can be installed independently of the monorepo.

Adds `webflow-content-design`, `sybg-guide`, `status-update`, and `dx-team-lookup`, including the content-design references and DX helper. The README now lists the workflow-skill category; moved skills use the destination namespace and no longer reference the monorepo path.

## QA Spec

- [x] Run the repository CI-equivalent structural checks; all 32 skill directories contain `SKILL.md` with `name:` and `description:` frontmatter.
- [x] Confirm each moved `SKILL.md` is within the repository’s 500-line limit.