### PR TITLE
chore(plugins): bump plugin version to 1.0.8

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Production-ready agent skills for Webflow - CMS management, site auditing, Designer tools, Code Components, CLI workflows, and safe publishing",
   "author": {
     "name": "Webflow",

--- a/plugins/webflow-skills/.claude-plugin/plugin.json
+++ b/plugins/webflow-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "skills": "./skills/"
 }

--- a/plugins/webflow-skills/.codex-plugin/plugin.json
+++ b/plugins/webflow-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webflow-skills",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Production-ready skills for managing Webflow CMS content, auditing site health, optimizing assets, building Designer pages and components, creating Code Components, running CLI workflows, and safely publishing changes.",
   "author": {
     "name": "Webflow",


### PR DESCRIPTION
## Summary

Bumps the plugin version `1.0.7` → `1.0.8` across all three provider manifests.

| File | Provider |
|---|---|
| `plugins/webflow-skills/.claude-plugin/plugin.json` | Claude |
| `plugins/webflow-skills/.codex-plugin/plugin.json` | Codex |
| `.cursor-plugin/plugin.json` | Cursor |

Version line only — no other changes.

## Why now

Two skill changes have merged since `1.0.7` (378a7fc, 2026-07-20) without a bump of their own:

- **#37** — the `webflow-cloud-command` rewrite (beta framing, eight newly documented commands, several corrections)
- **#44** — the new `cloud-apps` skill

One bump covers both. Precedent for a content-only change to an existing skill carrying a patch bump is c5d3013 (`1.0.4` → `1.0.5`), which edited this same cloud skill plus the three manifests in one PR. Every bump in this repo's history has been a patch, including ones that added a whole new skill, so `1.0.8` rather than a minor.

The two `marketplace.json` files carry no version and are deliberately untouched.

## Note

Nothing in CI checks these three against each other, so they can drift silently — worth keeping them in one commit whenever they move.
